### PR TITLE
fix(ci): scope renovate npm post-upgrade task to JS formatter

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           allowed_commands: |
             [
-              "^pnpm format$", 
+              "^pnpm format:js$", 
               "^go mod download$", 
               "^go mod download .*", 
               "^rm -f .*",

--- a/renovate.json
+++ b/renovate.json
@@ -60,7 +60,7 @@
       "matchManagers": ["npm"],
       "postUpdateOptions": ["pnpmDedupe"],
       "postUpgradeTasks": {
-        "commands": ["pnpm format"],
+        "commands": ["pnpm format:js"],
         "executionMode": "branch"
       }
     }


### PR DESCRIPTION
## Summary

Renovate's npm post-upgrade task ran `pnpm format`, which chains
`format:go && format:proto && format:js`. On an npm-only branch Renovate
provisions only the Node toolchain, so `go` is absent and the task aborts with
`sh: 1: go: not found` — failing the `renovate/artifacts` commit status (and
posting a "⚠️ Artifact update problem" comment) even though `pnpm-lock.yaml`
updated cleanly.

This scopes the npm post-upgrade task to `pnpm format:js` — the only formatter
relevant to a `package.json` / lockfile change, and the only one that can run in
the Renovate container — and narrows the workflow allow-list to match.

## Reproduction

The three open Renovate PRs on this repo (#352 `js-yaml`, #353 `globals`,
#354 `typescript-eslint`) are all green on every real CI job and red **only** on
`renovate/artifacts` for exactly this reason. Once this lands on `master`, the
hourly Renovate run rebases them and the check clears.

## Changes

- `renovate.json` — npm `postUpgradeTasks` command: `pnpm format` → `pnpm format:js`
- `.github/workflows/renovate.yaml` — allow-list: `^pnpm format$` → `^pnpm format:js$`

## Notes

The same fix is applied across `service-template` (the source these CI files are
re-baselined from) and all three services, so it does not regress on the next
re-baseline.

## Test plan

- [ ] After merge, the next Renovate run rebases #352 / #353 / #354 and `renovate/artifacts` goes green.
