### PR TITLE
style: apply prettier formatting after narrative-engine rewire

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The service runs as published OCI images plus a PostgreSQL database. The server 
 | ------------------------------------------ | --------------------------------------------------------------------------- |
 | `service-narrative-engine/rest`            | Public item CRUD + health API.                                              |
 | `service-narrative-engine/jobs/migrations` | One-shot schema migration job; runs to completion before the servers start. |
-| `service-narrative-engine/database`        | Pre-tuned PostgreSQL image — or bring your own Postgres.                     |
+| `service-narrative-engine/database`        | Pre-tuned PostgreSQL image — or bring your own Postgres.                    |
 
 Pin every image to the same release tag. A production deployment runs `database`, then `migrations` to completion, then any number of `rest` replicas:
 

--- a/pkg/js/rest/src/item.ts
+++ b/pkg/js/rest/src/item.ts
@@ -72,7 +72,12 @@ export async function itemList(api: NarrativeEngineApi, limit?: number, offset?:
   });
 }
 
-export async function itemUpdate(api: NarrativeEngineApi, id: string, name: string, description?: string): Promise<Item> {
+export async function itemUpdate(
+  api: NarrativeEngineApi,
+  id: string,
+  name: string,
+  description?: string
+): Promise<Item> {
   return await api.fetch(`/item`, ItemSchema, {
     method: "PUT",
     headers: HTTP_HEADERS.JSON,

--- a/pkg/js/test/rest/src/item.test.ts
+++ b/pkg/js/test/rest/src/item.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import { expectStatus } from "@a-novel-kit/nodelib-test/http";
-import { NarrativeEngineApi, itemCreate, itemDelete, itemGet, itemList, itemUpdate } from "@a-novel/service-narrative-engine-rest";
+import {
+  NarrativeEngineApi,
+  itemCreate,
+  itemDelete,
+  itemGet,
+  itemList,
+  itemUpdate,
+} from "@a-novel/service-narrative-engine-rest";
 
 describe("itemCreate", () => {
   it("creates a new item", async () => {


### PR DESCRIPTION
## What

Runs `prettier --write` over the three files the `lint-node` job flagged on master:

- `pkg/js/rest/src/item.ts` — one function signature wrapped
- `pkg/js/test/rest/src/item.test.ts` — one import wrapped
- `README.md` — canonical markdown formatting

## Why

The `service-template` → `service-narrative-engine` rewire lengthened the REST client identifiers (`TemplateApi` → `NarrativeEngineApi`, and the package name), pushing lines past prettier's print width. Reflow only — no behavior change.

Fixes the `lint-node` (`prettier --check`) failure. Verified locally with the exact CI command `pnpm lint:ci` (build + install + stylecheck + typecheck + eslint + openapi lint) — all green.

> [!NOTE]
> The separate `publish-docs` failure on master is **not** addressed here — it's a GitHub Pages settings issue (Pages not yet enabled for this new repo), not a code problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)