### PR TITLE
docs: refocus comments on rationale and refine project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ An A-Novel backend service. It currently ships a placeholder `item` resource —
 
 ## What it does
 
-The service's only domain object today is `item` — a named entity with an optional description — exposed through full CRUD. It demonstrates the [layered architecture](https://github.com/a-novel/.github/blob/master/CONTRIBUTING.md) (DAO → core → handler) and the client packages a real service inherits.
+The narrative-engine domain does not exist yet. Until it does, the service ships one placeholder resource — `item`, a named entity with an optional description — behind full CRUD, so that the surrounding machinery is wired and exercised end to end: the [layered architecture](https://github.com/a-novel/.github/blob/master/CONTRIBUTING.md) (DAO → core → handler), the published client packages, migrations, and health checks. Swapping `item` for the real domain then becomes an additive change rather than a build from scratch.
 
-The service exposes a **public REST API** (`cmd/rest`) — `/ping`, `/healthcheck`, and the `/items` + `/item` CRUD routes — for any HTTP client.
+The surface is a **public REST API**, served by `cmd/rest` and callable by any HTTP client: liveness and health endpoints alongside the `item` CRUD routes. Request and response shapes live in [`openapi.yaml`](./openapi.yaml).
 
 ## Deploying
 

--- a/cmd/migrations/main.go
+++ b/cmd/migrations/main.go
@@ -1,3 +1,5 @@
+// Command migrations brings the service database up to date by applying every pending schema
+// migration, then exits. It runs as a one-shot job before the REST server starts.
 package main
 
 import (
@@ -11,7 +13,6 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/models/migrations"
 )
 
-// Applies migrations.
 func main() {
 	ctx := lo.Must(postgres.NewContext(context.Background(), config.PostgresPresetDefault))
 	lo.Must0(postgres.RunMigrationsContext(ctx, migrations.Migrations))

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -1,3 +1,6 @@
+// Command rest wires the service layers together and runs the public REST server. It builds the
+// DAO, core, and handler stack, mounts the routes, and serves until a termination signal triggers
+// a graceful shutdown.
 package main
 
 import (
@@ -26,7 +29,6 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/handlers"
 )
 
-// Runs the main REST server.
 func main() {
 	cfg := config.AppPresetDefault
 	ctx := context.Background()

--- a/internal/config/app.config.default.go
+++ b/internal/config/app.config.default.go
@@ -15,27 +15,30 @@ import (
 )
 
 const (
+	// OtelFlushTimeout bounds how long shutdown waits for OpenTelemetry to flush buffered data.
 	OtelFlushTimeout = 2 * time.Second
 )
 
-// LoggerProd sends production-ready logs to Google Cloud environment.
+// LoggerProd sends production-ready logs to a Google Cloud environment.
 var LoggerProd = loggingpresets.GRPCGcloud{
 	Component: env.GcloudProjectId,
 }
 
-// LoggerDev prints logs in the console, pretty formatted.
+// LoggerDev pretty-prints logs to the console.
 var LoggerDev = loggingpresets.GRPCLocal{}
 
-// LoggerDevHttp prints HTTP-level logs in the console, pretty formatted.
+// LoggerDevHttp pretty-prints HTTP-level logs to the console.
 var LoggerDevHttp = &loggingpresets.LogLocal{
 	Out: os.Stdout,
 }
 
-// LoggerProdHttp sends HTTP-level production-ready logs to Google Cloud environment.
+// LoggerProdHttp sends production-ready HTTP-level logs to a Google Cloud environment.
 var LoggerProdHttp = &loggingpresets.LogGcloud{
 	ProjectId: env.GcloudProjectId,
 }
 
+// AppPresetDefault is the default application configuration, assembled from environment variables.
+// Logging and telemetry fall back to local presets when no Google Cloud project is configured.
 var AppPresetDefault = App{
 	App: Main{
 		Name: env.AppName,

--- a/internal/config/app.config.go
+++ b/internal/config/app.config.go
@@ -16,7 +16,7 @@ type RestCors struct {
 	MaxAge           int      `json:"maxAge"           yaml:"maxAge"`
 }
 
-// Main application configuration.
+// Main holds the top-level application settings.
 type Main struct {
 	// Name of the application, as it will appear in logs and tracing.
 	Name string `json:"name" yaml:"name"`
@@ -31,11 +31,11 @@ type RestTimeouts struct {
 	Request    time.Duration `json:"request"    yaml:"request"`
 }
 
-// Rest server configuration.
+// Rest holds the REST server configuration.
 type Rest struct {
 	// Port on which the REST server will listen for incoming requests.
 	Port int `json:"port" yaml:"port"`
-	// Timeouts holds the various timeout settings for the REST server.
+	// Timeouts groups the REST server timeout settings.
 	Timeouts RestTimeouts `json:"timeouts" yaml:"timeouts"`
 	// MaxRequestSize is the maximum size of an incoming request body.
 	MaxRequestSize int64 `json:"maxRequestSize" yaml:"maxRequestSize"`
@@ -43,6 +43,8 @@ type Rest struct {
 	Cors RestCors `json:"cors" yaml:"cors"`
 }
 
+// App is the root service configuration, aggregating the HTTP server, observability, and database
+// settings.
 type App struct {
 	App  Main `json:"app"  yaml:"app"`
 	Rest Rest `json:"rest" yaml:"rest"`

--- a/internal/config/configtest/postgres.go
+++ b/internal/config/configtest/postgres.go
@@ -8,15 +8,11 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/config/env"
 )
 
-// PostgresPreset is the PostgreSQL configuration used by integration tests
-// (DAO tests and health/status handler tests). It points at the same database
-// as the production preset; the test harness (postgres.RunTransactionalTest)
-// isolates each test in a rolled-back transaction.
+// PostgresPreset is the PostgreSQL configuration used by integration tests. It targets the same
+// database as the production preset; the transactional test harness isolates each test in a
+// rolled-back transaction.
 //
-// The Go toolchain has no notion of a "test-only" package (only the `_test.go`
-// file suffix is excluded from production builds, and that suffix wouldn't work
-// here because other test packages need to import this preset). The boundary is
-// a convention: production code never imports `configtest`, and a stray import
-// would be caught in review. See the write-go-tests skill, "Cross-Package Test
-// Fixtures".
+// Go has no test-only package: the `_test.go` suffix is the only build-time test exclusion, and it
+// cannot apply here because other test packages import this preset. The boundary is a convention —
+// production code never imports configtest.
 var PostgresPreset = postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))

--- a/internal/config/env/env.go
+++ b/internal/config/env/env.go
@@ -7,9 +7,8 @@ import (
 	"github.com/a-novel-kit/golib/config"
 )
 
-// Prefix allows to set a custom prefix to all configuration environment variables.
-// This is useful when importing the package in another project, when env variable names
-// might conflict with the source project.
+// prefix is prepended to every configuration environment variable name. Setting
+// SERVICE_NARRATIVE_ENGINE_ENV_PREFIX avoids name clashes when another project embeds this service.
 var prefix = os.Getenv("SERVICE_NARRATIVE_ENGINE_ENV_PREFIX")
 
 func getEnv(name string) string {
@@ -61,14 +60,14 @@ var (
 )
 
 var (
-	// PostgresDsn is the url used to connect to the postgres database instance.
+	// PostgresDsn is the URL used to connect to the PostgreSQL database instance.
 	// Typically formatted as:
 	//	postgres://<user>:<password>@<host>:<port>/<database>
 	PostgresDsn = postgresDsn
 
 	// AppName is the name of the application, as it will appear in logs and tracing.
 	AppName = config.LoadEnv(appName, AppNameDefault, config.StringParser)
-	// Otel flag configures whether to use Open Telemetry or not.
+	// Otel enables OpenTelemetry instrumentation.
 	//
 	// See: https://opentelemetry.io/
 	Otel = config.LoadEnv(otel, false, config.BoolParser)

--- a/internal/config/postgres.config.default.go
+++ b/internal/config/postgres.config.default.go
@@ -8,4 +8,6 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/config/env"
 )
 
+// PostgresPresetDefault is the default PostgreSQL connection configuration, built from the
+// POSTGRES_DSN environment variable.
 var PostgresPresetDefault = postgrespresets.NewDefault(pgdriver.WithDSN(env.PostgresDsn))

--- a/internal/core/itemCreate.go
+++ b/internal/core/itemCreate.go
@@ -14,10 +14,13 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/dao"
 )
 
+// ItemCreateDao is the DAO port ItemCreate depends on to persist a new item and
+// return the stored entity.
 type ItemCreateDao interface {
 	Exec(ctx context.Context, request *dao.ItemCreateRequest) (*dao.Item, error)
 }
 
+// ItemCreateRequest holds the validated input for [ItemCreate.Exec].
 type ItemCreateRequest struct {
 	Name        string `validate:"required,notblank,max=256"`
 	Description string `validate:"max=1024"`
@@ -28,6 +31,7 @@ type ItemCreate struct {
 	dao ItemCreateDao
 }
 
+// NewItemCreate builds an ItemCreate that persists through the given DAO.
 func NewItemCreate(dao ItemCreateDao) *ItemCreate {
 	return &ItemCreate{dao: dao}
 }

--- a/internal/core/itemDelete.go
+++ b/internal/core/itemDelete.go
@@ -13,14 +13,15 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/dao"
 )
 
+// ItemDeleteDao is the DAO port ItemDelete depends on to remove an item and
+// return the deleted entity.
 type ItemDeleteDao interface {
 	Exec(ctx context.Context, request *dao.ItemDeleteRequest) (*dao.Item, error)
 }
 
+// ItemDeleteRequest holds the input for [ItemDelete.Exec].
 type ItemDeleteRequest struct {
-	// ID identifies the item to remove; must be a non-zero UUID. `uuid.Nil`
-	// (the all-zero UUID) is almost always a missing path/query parameter
-	// rather than a real lookup.
+	// ID selects the item to remove; the required tag rejects the zero UUID.
 	ID uuid.UUID `validate:"required"`
 }
 
@@ -29,6 +30,7 @@ type ItemDelete struct {
 	dao ItemDeleteDao
 }
 
+// NewItemDelete builds an ItemDelete that persists through the given DAO.
 func NewItemDelete(dao ItemDeleteDao) *ItemDelete {
 	return &ItemDelete{dao: dao}
 }

--- a/internal/core/itemGet.go
+++ b/internal/core/itemGet.go
@@ -13,14 +13,14 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/dao"
 )
 
+// ItemGetDao is the DAO port ItemGet depends on to fetch a single item by its ID.
 type ItemGetDao interface {
 	Exec(ctx context.Context, request *dao.ItemGetRequest) (*dao.Item, error)
 }
 
+// ItemGetRequest holds the input for [ItemGet.Exec].
 type ItemGetRequest struct {
-	// ID identifies the item to fetch; must be a non-zero UUID. `uuid.Nil`
-	// (the all-zero UUID) is almost always a missing path/query parameter
-	// rather than a real lookup.
+	// ID selects the item to fetch; the required tag rejects the zero UUID.
 	ID uuid.UUID `validate:"required"`
 }
 
@@ -29,6 +29,7 @@ type ItemGet struct {
 	dao ItemGetDao
 }
 
+// NewItemGet builds an ItemGet that reads through the given DAO.
 func NewItemGet(dao ItemGetDao) *ItemGet {
 	return &ItemGet{dao: dao}
 }

--- a/internal/core/itemList.go
+++ b/internal/core/itemList.go
@@ -12,6 +12,7 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/dao"
 )
 
+// ItemListDao is the DAO port ItemList depends on to read a page of items.
 type ItemListDao interface {
 	Exec(ctx context.Context, request *dao.ItemListRequest) ([]*dao.Item, error)
 }
@@ -25,8 +26,9 @@ const (
 	ItemListMaxSize = 100
 )
 
+// ItemListRequest holds the pagination input for [ItemList.Exec].
 type ItemListRequest struct {
-	// Limit defaults to ItemListDefaultSize when zero or negative; see Exec.
+	// Limit falls back to ItemListDefaultSize when zero or negative.
 	Limit  int `validate:"max=100"`
 	Offset int `validate:"min=0"`
 }
@@ -36,6 +38,7 @@ type ItemList struct {
 	dao ItemListDao
 }
 
+// NewItemList builds an ItemList that reads through the given DAO.
 func NewItemList(dao ItemListDao) *ItemList {
 	return &ItemList{dao: dao}
 }
@@ -44,8 +47,7 @@ func (service *ItemList) Exec(ctx context.Context, request *ItemListRequest) ([]
 	ctx, span := otel.Tracer().Start(ctx, "service.ItemList")
 	defer span.End()
 
-	// Resolve the effective page size without mutating the caller's request:
-	// a zero or negative Limit means "use the default".
+	// Resolve the page size into a local so the caller's request stays untouched.
 	limit := request.Limit
 	if limit <= 0 {
 		limit = ItemListDefaultSize

--- a/internal/core/itemUpdate.go
+++ b/internal/core/itemUpdate.go
@@ -14,10 +14,14 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/dao"
 )
 
+// ItemUpdateDao is the DAO port ItemUpdate depends on to overwrite an item's
+// fields and return the stored entity.
 type ItemUpdateDao interface {
 	Exec(ctx context.Context, request *dao.ItemUpdateRequest) (*dao.Item, error)
 }
 
+// ItemUpdateRequest holds the validated input for [ItemUpdate.Exec]; ID selects
+// the item to modify.
 type ItemUpdateRequest struct {
 	ID          uuid.UUID
 	Name        string `validate:"required,notblank,max=256"`
@@ -29,6 +33,7 @@ type ItemUpdate struct {
 	dao ItemUpdateDao
 }
 
+// NewItemUpdate builds an ItemUpdate that persists through the given DAO.
 func NewItemUpdate(dao ItemUpdateDao) *ItemUpdate {
 	return &ItemUpdate{dao: dao}
 }

--- a/internal/core/validate.go
+++ b/internal/core/validate.go
@@ -9,10 +9,13 @@ import (
 
 var validate = validator.New(validator.WithRequiredStructEnabled())
 
+// ErrInvalidRequest is joined into the error returned by a service's Exec when
+// the request fails struct validation. Callers match against it to map the
+// failure to a client error.
 var ErrInvalidRequest = errors.New("invalid request")
 
-// ValidateNotBlank is a custom validator that ensures a string is not empty after trimming whitespace.
-// Use the "notblank" tag to apply it.
+// ValidateNotBlank reports whether a string holds a non-whitespace character.
+// Apply it with the "notblank" struct tag.
 func ValidateNotBlank(fl validator.FieldLevel) bool {
 	return strings.TrimSpace(fl.Field().String()) != ""
 }

--- a/internal/dao/pg.item.go
+++ b/internal/dao/pg.item.go
@@ -7,7 +7,7 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// Item is a placeholder resource stored in the database.
+// An Item is a placeholder resource stored in the database.
 type Item struct {
 	bun.BaseModel `bun:"table:items,alias:items"`
 

--- a/internal/dao/pg.itemCreate.go
+++ b/internal/dao/pg.itemCreate.go
@@ -16,16 +16,19 @@ import (
 //go:embed pg.itemCreate.sql
 var itemCreateQuery string
 
+// ItemCreateRequest holds the parameters for an [ItemCreate.Exec] call.
 type ItemCreateRequest struct {
 	ID          uuid.UUID
 	Name        string
 	Description string
-	Now         time.Time
+	// Now is the timestamp recorded as the item's creation time.
+	Now time.Time
 }
 
-// ItemCreate inserts a new item into the database.
+// An ItemCreate inserts a new item into the database.
 type ItemCreate struct{}
 
+// NewItemCreate returns a new ItemCreate DAO.
 func NewItemCreate() *ItemCreate {
 	return new(ItemCreate)
 }

--- a/internal/dao/pg.itemDelete.go
+++ b/internal/dao/pg.itemDelete.go
@@ -17,15 +17,18 @@ import (
 //go:embed pg.itemDelete.sql
 var itemDeleteQuery string
 
+// ErrItemDeleteNotFound is returned when no item matches the delete request.
 var ErrItemDeleteNotFound = errors.New("item not found")
 
+// ItemDeleteRequest holds the parameters for an [ItemDelete.Exec] call.
 type ItemDeleteRequest struct {
 	ID uuid.UUID
 }
 
-// ItemDelete permanently removes an item by its ID.
+// An ItemDelete permanently removes an item by its ID.
 type ItemDelete struct{}
 
+// NewItemDelete returns a new ItemDelete DAO.
 func NewItemDelete() *ItemDelete {
 	return new(ItemDelete)
 }

--- a/internal/dao/pg.itemGet.go
+++ b/internal/dao/pg.itemGet.go
@@ -17,15 +17,18 @@ import (
 //go:embed pg.itemGet.sql
 var itemGetQuery string
 
+// ErrItemGetNotFound is returned when no item matches the requested ID.
 var ErrItemGetNotFound = errors.New("item not found")
 
+// ItemGetRequest holds the parameters for an [ItemGet.Exec] call.
 type ItemGetRequest struct {
 	ID uuid.UUID
 }
 
-// ItemGet retrieves an item by its ID.
+// An ItemGet retrieves an item by its ID.
 type ItemGet struct{}
 
+// NewItemGet returns a new ItemGet DAO.
 func NewItemGet() *ItemGet {
 	return new(ItemGet)
 }

--- a/internal/dao/pg.itemList.go
+++ b/internal/dao/pg.itemList.go
@@ -14,14 +14,16 @@ import (
 //go:embed pg.itemList.sql
 var itemListQuery string
 
+// ItemListRequest holds the parameters for an [ItemList.Exec] call.
 type ItemListRequest struct {
 	Limit  int
 	Offset int
 }
 
-// ItemList retrieves a paginated list of items ordered by creation date (newest first).
+// An ItemList retrieves a paginated list of items ordered by creation date, newest first.
 type ItemList struct{}
 
+// NewItemList returns a new ItemList DAO.
 func NewItemList() *ItemList {
 	return new(ItemList)
 }

--- a/internal/dao/pg.itemUpdate.go
+++ b/internal/dao/pg.itemUpdate.go
@@ -18,18 +18,22 @@ import (
 //go:embed pg.itemUpdate.sql
 var itemUpdateQuery string
 
+// ErrItemUpdateNotFound is returned when no item matches the update request.
 var ErrItemUpdateNotFound = errors.New("item not found")
 
+// ItemUpdateRequest holds the parameters for an [ItemUpdate.Exec] call.
 type ItemUpdateRequest struct {
 	ID          uuid.UUID
 	Name        string
 	Description string
-	Now         time.Time
+	// Now is the timestamp recorded as the item's last-update time.
+	Now time.Time
 }
 
-// ItemUpdate modifies the name and description of an existing item.
+// An ItemUpdate modifies the name and description of an existing item.
 type ItemUpdate struct{}
 
+// NewItemUpdate returns a new ItemUpdate DAO.
 func NewItemUpdate() *ItemUpdate {
 	return new(ItemUpdate)
 }

--- a/internal/handlers/http.decoder.go
+++ b/internal/handlers/http.decoder.go
@@ -2,4 +2,6 @@ package handlers
 
 import "github.com/gorilla/schema"
 
+// muxDecoder decodes URL query parameters into request structs tagged with `schema`.
+// Shared by the handlers that read their input from the query string rather than the body.
 var muxDecoder = schema.NewDecoder()

--- a/internal/handlers/http.health.go
+++ b/internal/handlers/http.health.go
@@ -13,15 +13,22 @@ import (
 )
 
 const (
-	RestHealthStatusUp   = "up"
+	// RestHealthStatusUp is the status reported when a dependency is reachable.
+	RestHealthStatusUp = "up"
+	// RestHealthStatusDown is the status reported when a dependency is unreachable.
 	RestHealthStatusDown = "down"
 )
 
+// RestHealthStatus is the JSON representation of a single dependency's health.
 type RestHealthStatus struct {
+	// Status is either [RestHealthStatusUp] or [RestHealthStatusDown].
 	Status string `json:"status"`
-	Err    string `json:"err,omitempty"`
+	// Err carries the failure message when the dependency is down; empty when it is up.
+	Err string `json:"err,omitempty"`
 }
 
+// NewRestHealthStatus builds a RestHealthStatus from a dependency probe result, mapping a
+// nil error to [RestHealthStatusUp] and any non-nil error to [RestHealthStatusDown].
 func NewRestHealthStatus(err error) *RestHealthStatus {
 	errMsg := ""
 	if err != nil {
@@ -34,8 +41,11 @@ func NewRestHealthStatus(err error) *RestHealthStatus {
 	}
 }
 
+// RestHealth is the REST handler that reports the operational health of the service and
+// its dependencies as a JSON object keyed by dependency.
 type RestHealth struct{}
 
+// NewRestHealth returns a new RestHealth handler.
 func NewRestHealth() *RestHealth {
 	return &RestHealth{}
 }
@@ -60,7 +70,8 @@ func (handler *RestHealth) reportPostgres(ctx context.Context) error {
 
 	pgdb, ok := pg.(*bun.DB)
 	if !ok {
-		// Cannot assess db connection if we are running on transaction mode
+		// In transaction mode the pool is a transaction rather than a *bun.DB, so there is
+		// no connection to ping; report healthy.
 		return nil
 	}
 

--- a/internal/handlers/http.item.go
+++ b/internal/handlers/http.item.go
@@ -8,6 +8,7 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/core"
 )
 
+// Item is the JSON representation of a narrative item returned by the REST API.
 type Item struct {
 	ID          uuid.UUID `json:"id"`
 	Name        string    `json:"name"`
@@ -16,6 +17,7 @@ type Item struct {
 	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
+// loadItem maps a core item onto its REST representation.
 func loadItem(s *core.Item) Item {
 	return Item{
 		ID:          s.ID,
@@ -26,6 +28,7 @@ func loadItem(s *core.Item) Item {
 	}
 }
 
+// loadItemMap adapts loadItem to the signature lo.Map expects, ignoring the slice index.
 func loadItemMap(item *core.Item, _ int) Item {
 	return loadItem(item)
 }

--- a/internal/handlers/http.itemCreatePublic.go
+++ b/internal/handlers/http.itemCreatePublic.go
@@ -12,20 +12,24 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/core"
 )
 
+// ItemCreatePublicService is the service port ItemCreatePublic depends on to create an item.
 type ItemCreatePublicService interface {
 	Exec(ctx context.Context, request *core.ItemCreateRequest) (*core.Item, error)
 }
 
+// ItemCreatePublicRequest is the JSON body accepted by the create-item endpoint.
 type ItemCreatePublicRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 }
 
+// ItemCreatePublic is the REST handler that creates a new item.
 type ItemCreatePublic struct {
 	service ItemCreatePublicService
 	logger  logging.Log
 }
 
+// NewItemCreatePublic returns a new ItemCreatePublic handler backed by the given service.
 func NewItemCreatePublic(service ItemCreatePublicService, logger logging.Log) *ItemCreatePublic {
 	return &ItemCreatePublic{service: service, logger: logger}
 }

--- a/internal/handlers/http.itemDeletePublic.go
+++ b/internal/handlers/http.itemDeletePublic.go
@@ -14,19 +14,24 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/dao"
 )
 
+// ItemDeletePublicService is the service port ItemDeletePublic depends on to delete an item
+// and return the deleted record.
 type ItemDeletePublicService interface {
 	Exec(ctx context.Context, request *core.ItemDeleteRequest) (*core.Item, error)
 }
 
+// ItemDeletePublicRequest is the query string accepted by the delete-item endpoint.
 type ItemDeletePublicRequest struct {
 	ID uuid.UUID `schema:"id"`
 }
 
+// ItemDeletePublic is the REST handler that deletes an item by ID.
 type ItemDeletePublic struct {
 	service ItemDeletePublicService
 	logger  logging.Log
 }
 
+// NewItemDeletePublic returns a new ItemDeletePublic handler backed by the given service.
 func NewItemDeletePublic(service ItemDeletePublicService, logger logging.Log) *ItemDeletePublic {
 	return &ItemDeletePublic{service: service, logger: logger}
 }

--- a/internal/handlers/http.itemGetPublic.go
+++ b/internal/handlers/http.itemGetPublic.go
@@ -14,19 +14,23 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/dao"
 )
 
+// ItemGetPublicService is the service port ItemGetPublic depends on to fetch a single item.
 type ItemGetPublicService interface {
 	Exec(ctx context.Context, request *core.ItemGetRequest) (*core.Item, error)
 }
 
+// ItemGetPublicRequest is the query string accepted by the get-item endpoint.
 type ItemGetPublicRequest struct {
 	ID uuid.UUID `schema:"id"`
 }
 
+// ItemGetPublic is the REST handler that fetches a single item by ID.
 type ItemGetPublic struct {
 	service ItemGetPublicService
 	logger  logging.Log
 }
 
+// NewItemGetPublic returns a new ItemGetPublic handler backed by the given service.
 func NewItemGetPublic(service ItemGetPublicService, logger logging.Log) *ItemGetPublic {
 	return &ItemGetPublic{service: service, logger: logger}
 }

--- a/internal/handlers/http.itemListPublic.go
+++ b/internal/handlers/http.itemListPublic.go
@@ -13,20 +13,25 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/core"
 )
 
+// ItemListPublicService is the service port ItemListPublic depends on to list items.
 type ItemListPublicService interface {
 	Exec(ctx context.Context, request *core.ItemListRequest) ([]*core.Item, error)
 }
 
+// ItemListPublicRequest is the query string accepted by the list-items endpoint. Limit and
+// Offset paginate the result set.
 type ItemListPublicRequest struct {
 	Limit  int `schema:"limit"`
 	Offset int `schema:"offset"`
 }
 
+// ItemListPublic is the REST handler that lists items page by page.
 type ItemListPublic struct {
 	service ItemListPublicService
 	logger  logging.Log
 }
 
+// NewItemListPublic returns a new ItemListPublic handler backed by the given service.
 func NewItemListPublic(service ItemListPublicService, logger logging.Log) *ItemListPublic {
 	return &ItemListPublic{service: service, logger: logger}
 }

--- a/internal/handlers/http.itemUpdatePublic.go
+++ b/internal/handlers/http.itemUpdatePublic.go
@@ -15,21 +15,26 @@ import (
 	"github.com/a-novel/service-narrative-engine/internal/dao"
 )
 
+// ItemUpdatePublicService is the service port ItemUpdatePublic depends on to update an item
+// and return the updated record.
 type ItemUpdatePublicService interface {
 	Exec(ctx context.Context, request *core.ItemUpdateRequest) (*core.Item, error)
 }
 
+// ItemUpdatePublicRequest is the JSON body accepted by the update-item endpoint.
 type ItemUpdatePublicRequest struct {
 	ID          uuid.UUID `json:"id"`
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
 }
 
+// ItemUpdatePublic is the REST handler that updates an existing item.
 type ItemUpdatePublic struct {
 	service ItemUpdatePublicService
 	logger  logging.Log
 }
 
+// NewItemUpdatePublic returns a new ItemUpdatePublic handler backed by the given service.
 func NewItemUpdatePublic(service ItemUpdatePublicService, logger logging.Log) *ItemUpdatePublic {
 	return &ItemUpdatePublic{service: service, logger: logger}
 }

--- a/internal/handlers/http.ping.go
+++ b/internal/handlers/http.ping.go
@@ -6,8 +6,10 @@ import (
 	"github.com/a-novel-kit/golib/otel"
 )
 
+// Ping is the REST handler that responds with "pong" for liveness checks.
 type Ping struct{}
 
+// NewPing returns a new Ping handler.
 func NewPing() *Ping {
 	return new(Ping)
 }

--- a/internal/models/migrations/migrations.go
+++ b/internal/models/migrations/migrations.go
@@ -1,8 +1,12 @@
+// Package migrations holds the SQL schema migrations for the service, embedded
+// so the migration runner can apply them without reading from disk at runtime.
 package migrations
 
 import (
 	"embed"
 )
 
+// Migrations embeds every SQL migration file in this directory.
+//
 //go:embed *.sql
 var Migrations embed.FS

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,3 @@
-# Created with https://editor.swagger.io/
 openapi: 3.1.0
 
 servers:
@@ -28,8 +27,8 @@ paths:
       description: |
         A simple endpoint to check if the server is up and running. It always returns the same response.
 
-        Note this **DOES NOT** give information about the server dependencies. To get more information about the
-        server actual health, please use the `/healthcheck` endpoint.
+        It does not check the server dependencies; use the `/healthcheck` endpoint to diagnose the server's
+        actual health.
       tags: [health]
       security: []
       responses:
@@ -161,7 +160,7 @@ paths:
 components:
   responses:
     pong:
-      description: "101100001100101011001010"
+      description: A plain-text pong response.
       content:
         text/plain:
           schema:
@@ -215,7 +214,7 @@ components:
   schemas:
     healthStatus:
       type: object
-      description: Summary of a server's dependencies status.
+      description: Connection status of a single server dependency.
       required: [status]
       examples:
         - { "status": "up" }
@@ -223,7 +222,7 @@ components:
       properties:
         status:
           type: string
-          description: Exposes whether the server managed to connect to the dependency.
+          description: Whether the server could reach the dependency.
           enum: [up, down]
         err:
           type: string

--- a/pkg/js/rest/src/api.ts
+++ b/pkg/js/rest/src/api.ts
@@ -2,15 +2,27 @@ import { decodeHttpResponse, handleHttpResponse } from "@a-novel-kit/nodelib-bro
 
 import type { ZodType } from "zod";
 
+// Fallback decoder used by fetch when no Zod validator is supplied: the body is
+// trusted as-is and returned without schema validation.
 async function decodeRawHttpResponse<T>(response: Response): Promise<T> {
   return await response.json();
 }
 
+/** Health status of a single service dependency reported by the `/healthcheck` endpoint. */
 export type HealthDependency = {
+  /** Whether the dependency is reachable. */
   status: "up" | "down";
+  /** Error detail present when the dependency is down. */
   err?: string;
 };
 
+/**
+ * HTTP client for the narrative-engine REST API.
+ *
+ * It holds the service base URL and exposes the low-level request helpers that the
+ * module-level `item*` functions build on. Pass an instance to those functions to
+ * issue the individual endpoint calls.
+ */
 export class NarrativeEngineApi {
   private readonly _baseUrl: string;
 
@@ -18,20 +30,35 @@ export class NarrativeEngineApi {
     this._baseUrl = baseUrl;
   }
 
+  /**
+   * Sends a request to the given path and discards the response body.
+   * Throws if the server returns a non-2xx status.
+   */
   async fetchVoid(input: string, init?: RequestInit): Promise<void> {
     await fetch(`${this._baseUrl}${input}`, init).then(handleHttpResponse);
   }
 
+  /**
+   * Sends a request to the given path and deserializes the JSON response body as `T`.
+   * When a validator is given, the body is parsed and validated against it; otherwise
+   * it is returned unchecked. Throws if the server returns a non-2xx status.
+   */
   async fetch<T>(input: string, validator?: ZodType<T>, init?: RequestInit): Promise<T> {
     return await fetch(`${this._baseUrl}${input}`, init)
       .then(handleHttpResponse)
       .then(validator ? decodeHttpResponse(validator) : decodeRawHttpResponse<T>);
   }
 
+  /** Checks that the server is reachable. Throws on any non-2xx response. */
   async ping(): Promise<void> {
     await this.fetchVoid("/ping", { method: "GET" });
   }
 
+  /**
+   * Returns the health status of every service dependency, keyed by dependency name.
+   * The endpoint always responds 200; inspect each entry's `status` field to detect a
+   * degraded dependency.
+   */
   async health(): Promise<Record<string, HealthDependency>> {
     return await this.fetch("/healthcheck", undefined, { method: "GET" });
   }

--- a/pkg/js/rest/src/item.ts
+++ b/pkg/js/rest/src/item.ts
@@ -80,7 +80,8 @@ export async function itemGet(api: NarrativeEngineApi, id: string): Promise<Item
 }
 
 /**
- * Returns a page of Items. When omitted, `limit` defaults to 100 and `offset` to 0.
+ * Returns a page of Items. `limit` defaults to 100 and `offset` to 0 when omitted; a `limit` of 0
+ * also falls back to 100.
  */
 export async function itemList(api: NarrativeEngineApi, limit?: number, offset?: number): Promise<Item[]> {
   const params = new URLSearchParams();

--- a/pkg/js/rest/src/item.ts
+++ b/pkg/js/rest/src/item.ts
@@ -4,6 +4,10 @@ import { HTTP_HEADERS } from "@a-novel-kit/nodelib-browser/http";
 
 import { z } from "zod";
 
+/**
+ * Runtime schema for an Item returned by the narrative-engine REST API. The `createdAt`
+ * and `updatedAt` timestamps arrive as ISO strings and are parsed into `Date` objects.
+ */
 export const ItemSchema = z.object({
   id: z.uuid(),
   name: z.string(),
@@ -12,42 +16,54 @@ export const ItemSchema = z.object({
   updatedAt: z.iso.datetime().transform((value) => new Date(value)),
 });
 
+/** An Item record stored by the narrative-engine service. */
 export type Item = z.infer<typeof ItemSchema>;
 
+/** Schema for the body accepted when creating an Item. */
 export const ItemCreateRequestSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
 });
 
+/** Body accepted by {@link itemCreate}. */
 export type ItemCreateRequest = z.infer<typeof ItemCreateRequestSchema>;
 
+/** Schema for the parameters that select a single Item to fetch. */
 export const ItemGetRequestSchema = z.object({
   id: z.uuid(),
 });
 
+/** Parameters accepted by {@link itemGet}. */
 export type ItemGetRequest = z.infer<typeof ItemGetRequestSchema>;
 
+/** Schema for the pagination parameters when listing Items. */
 export const ItemListRequestSchema = z.object({
   limit: z.int().min(1).max(100).optional(),
   offset: z.int().min(0).optional(),
 });
 
+/** Parameters accepted by {@link itemList}. */
 export type ItemListRequest = z.infer<typeof ItemListRequestSchema>;
 
+/** Schema for the body accepted when updating an Item. */
 export const ItemUpdateRequestSchema = z.object({
   id: z.uuid(),
   name: z.string(),
   description: z.string().optional(),
 });
 
+/** Body accepted by {@link itemUpdate}. */
 export type ItemUpdateRequest = z.infer<typeof ItemUpdateRequestSchema>;
 
+/** Schema for the parameters that select a single Item to delete. */
 export const ItemDeleteRequestSchema = z.object({
   id: z.uuid(),
 });
 
+/** Parameters accepted by {@link itemDelete}. */
 export type ItemDeleteRequest = z.infer<typeof ItemDeleteRequestSchema>;
 
+/** Creates an Item with the given name and optional description, returning the stored record. */
 export async function itemCreate(api: NarrativeEngineApi, name: string, description?: string): Promise<Item> {
   return await api.fetch("/items", ItemSchema, {
     method: "POST",
@@ -56,12 +72,16 @@ export async function itemCreate(api: NarrativeEngineApi, name: string, descript
   });
 }
 
+/** Returns a single Item by its ID. */
 export async function itemGet(api: NarrativeEngineApi, id: string): Promise<Item> {
   const params = new URLSearchParams();
   params.set("id", id);
   return await api.fetch(`/item?${params.toString()}`, ItemSchema, { method: "GET", headers: HTTP_HEADERS.JSON });
 }
 
+/**
+ * Returns a page of Items. When omitted, `limit` defaults to 100 and `offset` to 0.
+ */
 export async function itemList(api: NarrativeEngineApi, limit?: number, offset?: number): Promise<Item[]> {
   const params = new URLSearchParams();
   params.set("limit", `${limit || 100}`);
@@ -72,6 +92,7 @@ export async function itemList(api: NarrativeEngineApi, limit?: number, offset?:
   });
 }
 
+/** Replaces the name and description of the Item with the given ID, returning the updated record. */
 export async function itemUpdate(
   api: NarrativeEngineApi,
   id: string,
@@ -85,6 +106,7 @@ export async function itemUpdate(
   });
 }
 
+/** Deletes the Item with the given ID, returning the deleted record. */
 export async function itemDelete(api: NarrativeEngineApi, id: string): Promise<Item> {
   const params = new URLSearchParams();
   params.set("id", id);


### PR DESCRIPTION
## Summary

Sweeps in-code comments and the project docs (README/CONTRIBUTING) against the sharpened documentation contract: **rationale over restatement**, plain voice, comments paced as navigation. Removes copy-pasted spec text in favor of concise prose plus the authoritative link, adds missing docs on exported symbols, and corrects claims that had drifted from the code.

## Scope

Comments and documentation only — **no code changed** (verified: code tokens are identical after ignoring comments and whitespace across every `.go`/`.ts`/`.proto` file). Excluded: `.github/**` (managed by `a-novel repo update`), `builds/**` (deployment infra), generated/test files, `CODE_OF_CONDUCT`/`LICENSE`.

## Test plan

- [x] Repo formatter is a no-op after the sweep
- [x] Comment-only gate passes
- [ ] CI green