### PR TITLE
perf(ci): adopt gha docker build cache (workflows v1.15.6)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.15.6
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.15.6
 
   lint-node:
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.15.6
         id: test
         with:
           filter_extra_patterns: "| grep /internal"
@@ -120,7 +120,7 @@ jobs:
     env:
       REST_URL: "http://localhost:8080"
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.15.6
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -145,11 +145,12 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         id: build
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
+          cache: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: >-
             -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" 
@@ -185,7 +186,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -221,7 +222,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -259,7 +260,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -274,7 +275,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.15.4
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -288,7 +289,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.15.4
+      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.15.6
         if: github.ref == 'refs/heads/master' && success()
 
   report-codecov:
@@ -297,7 +298,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.15.6
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.15.4
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.15.6
         with:
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
@@ -71,10 +71,11 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
+          cache: false
           version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           run_args: >-
@@ -112,7 +113,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.15.6
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -150,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -188,7 +189,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.4
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.15.6
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -206,7 +207,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.15.4
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.15.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -227,7 +228,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.15.4
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.15.6
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adopts the cross-run Docker build cache shipped in `a-novel-kit/workflows` v1.15.6 (keystone a-novel-kit/workflows#280):

- Bumps the `a-novel-kit/workflows` pin `v1.15.4 → v1.15.6` (adds `type=gha,mode=max` layer cache, scoped per image).
- Passes `cache: false` on the postgres `build-database` job (`main.yaml` + `release.yaml`) — caching its large base to GHA is a net loss and it gates the test job on the critical path.



Part of the **Build & CI performance** Initiative (a-novel/.github#172), Epic a-novel/.github#173. Benchmarked on service-authentication: ~−30% total wall-clock warm, Go image builds −36% to −64%.

## Breaking changes

None. Additive CI-only change.

## Test plan

- [ ] main CI green (first run populates the cache; subsequent runs are warm)