### PR TITLE
perf(builds): cache mounts, modern builder shape, fix .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,22 @@
-# Ignore test files
+# Version control and CI — never needed in builds.
+.git
+.github
+.claude
+
+# Node toolchain — large and irrelevant to Go builds (~600MB was previously
+# shipped to the build daemon on every build).
+node_modules
+
+# Test files — excluded from production images.
 **/*_test.go
 **/*.test.go
 
-.github
-scripts
+# Go client package — not part of any server build.
+pkg/
+
+# Scripts, docs, and frontend config — not part of any server build.
+scripts/
+*.md
 **/*.ts
 **/*.js
+coverage/

--- a/builds/migrations.Dockerfile
+++ b/builds/migrations.Dockerfile
@@ -1,31 +1,27 @@
 # This image runs a job that will apply the latest migrations to a database instance.
 FROM docker.io/library/golang:1.26.4-alpine AS builder
 
+ENV CGO_ENABLED=0
+
 WORKDIR /app
 
-# ======================================================================================================================
-# Copy build files.
-# ======================================================================================================================
-COPY ./go.mod ./go.mod
-COPY ./go.sum ./go.sum
-COPY "./cmd/migrations" "./cmd/migrations"
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY ./cmd/migrations ./cmd/migrations
 COPY ./internal/config ./internal/config
 COPY ./internal/models/migrations ./internal/models/migrations
 
-RUN go mod download
-
-# ======================================================================================================================
-# Build executables.
-# ======================================================================================================================
-RUN go build -o /migrations cmd/migrations/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /migrations ./cmd/migrations/
 
 FROM docker.io/library/alpine:3.24.1
 
 WORKDIR /
 
 COPY --from=builder /migrations /migrations
-
-ARG DEBIAN_FRONTEND=noninteractive
 
 # Applies the migrations to a linked database instance.
 CMD ["/migrations"]

--- a/builds/rest.Dockerfile
+++ b/builds/rest.Dockerfile
@@ -3,26 +3,32 @@
 # It requires a patched database instance to run properly.
 FROM docker.io/library/golang:1.26.4-alpine AS builder
 
+# Static binary: no libc dependency, so it runs on a bare alpine base.
+ENV CGO_ENABLED=0
+
 WORKDIR /app
 
-# ======================================================================================================================
-# Copy build files.
-# ======================================================================================================================
-COPY ./go.mod ./go.mod
-COPY ./go.sum ./go.sum
-COPY "./cmd/rest" "./cmd/rest"
+# Resolve modules off go.mod/go.sum alone, before the source, so the download
+# layer survives any source-only edit. The cache mount persists the module cache
+# across builds — locally this turns a cold re-pull into a no-op; in CI the gha
+# layer cache covers cross-run reuse.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY ./cmd/rest ./cmd/rest
 COPY ./internal/handlers ./internal/handlers
 COPY ./internal/dao ./internal/dao
 COPY ./internal/core ./internal/core
 COPY ./internal/models ./internal/models
 COPY ./internal/config ./internal/config
 
-RUN go mod download
-
-# ======================================================================================================================
-# Build executables.
-# ======================================================================================================================
-RUN go build -o /rest cmd/rest/main.go
+# Cache mounts persist the module + build cache across builds, so a rebuild after
+# a source change recompiles only the changed packages. -ldflags="-s -w" strips
+# the symbol table + DWARF (smaller binary); -trimpath drops absolute paths.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /rest ./cmd/rest/
 
 FROM docker.io/library/alpine:3.24.1
 
@@ -30,17 +36,10 @@ WORKDIR /
 
 COPY --from=builder /rest /rest
 
-# ======================================================================================================================
-# Healthcheck.
-# ======================================================================================================================
-RUN apk --update add curl
-
+# Alpine ships BusyBox wget — no extra package needed for the healthcheck.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
-  CMD curl -f http://localhost:8080/ping || exit 1
+  CMD wget -qO /dev/null http://localhost:8080/ping || exit 1
 
-# ======================================================================================================================
-# Finish setup.
-# ======================================================================================================================
 # Make sure the executable uses the default port.
 ENV REST_PORT=8080
 

--- a/builds/standalone.rest.Dockerfile
+++ b/builds/standalone.rest.Dockerfile
@@ -6,28 +6,27 @@
 # version of the base REST image, suited for local development rather than full scale production.
 FROM docker.io/library/golang:1.26.4-alpine AS builder
 
+ENV CGO_ENABLED=0
+
 WORKDIR /app
 
-# ======================================================================================================================
-# Copy build files.
-# ======================================================================================================================
-COPY ./go.mod ./go.mod
-COPY ./go.sum ./go.sum
-COPY "./cmd/rest" "./cmd/rest"
-COPY "./cmd/migrations" "./cmd/migrations"
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY ./cmd/rest ./cmd/rest
+COPY ./cmd/migrations ./cmd/migrations
 COPY ./internal/handlers ./internal/handlers
 COPY ./internal/dao ./internal/dao
 COPY ./internal/core ./internal/core
 COPY ./internal/models ./internal/models
 COPY ./internal/config ./internal/config
 
-RUN go mod download
-
-# ======================================================================================================================
-# Build executables.
-# ======================================================================================================================
-RUN go build -o /rest cmd/rest/main.go
-RUN go build -o /migrations cmd/migrations/main.go
+# One RUN so the two binaries share a single warm module + build cache.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w" -trimpath -o /rest ./cmd/rest/ && \
+    go build -ldflags="-s -w" -trimpath -o /migrations ./cmd/migrations/
 
 FROM docker.io/library/alpine:3.24.1
 
@@ -36,17 +35,10 @@ WORKDIR /
 COPY --from=builder /rest /rest
 COPY --from=builder /migrations /migrations
 
-# ======================================================================================================================
-# Healthcheck.
-# ======================================================================================================================
-RUN apk --update add curl
-
+# Alpine ships BusyBox wget — no extra package needed for the healthcheck.
 HEALTHCHECK --interval=1s --timeout=5s --retries=10 --start-period=1s \
-  CMD curl -f http://localhost:8080/ping || exit 1
+  CMD wget -qO /dev/null http://localhost:8080/ping || exit 1
 
-# ======================================================================================================================
-# Finish setup.
-# ======================================================================================================================
 # Make sure the executable uses the default port.
 ENV REST_PORT=8080
 


### PR DESCRIPTION
## Summary

Modernizes the three Go builders and fixes the build context:

- **`.dockerignore`**: excluded neither `node_modules` nor `.git`, so **~565 MB** of context (mostly `node_modules`) was tarred to the build daemon on **every** build — local and CI. Now ships only the Go sources (a few MB). Biggest local-resource win in this service. `pkg/` is ignored too (the builders don't COPY it).
- **Cache mounts** (`/go/pkg/mod` + `/root/.cache/go-build`) on all three builders — rebuilds reuse the previous compilation.
- **json-keys shape**: `CGO_ENABLED=0` + `-ldflags="-s -w" -trimpath` (smaller static binary), `go.mod`-before-source (module layer survives edits), BusyBox `wget` healthcheck (drops the `apk add curl`). Removes a stray no-op `DEBIAN_FRONTEND` ARG.

Verified locally (rest image builds in ~14s with the trimmed context). Closes #373. Part of Epic a-novel/.github#173.

## Breaking changes

None. builds-only; same binaries, same entrypoints.

## Test plan

- [ ] CI `build-rest` / `build-standalone-rest` / `build-migrations` build and report healthy
- [x] Local: rest image builds; context drops from ~565 MB to a few MB