### PR TITLE
perf(ci): skip build-standalone-rest smoke test (workflows v1.18.0)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.17.1
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.18.0
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.17.1
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.18.0
 
   lint-node:
     runs-on: ubuntu-latest
@@ -38,7 +38,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.17.1
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.18.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.17.1
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.18.0
         id: test
         with:
           filter_extra_patterns: "| grep /internal"
@@ -120,7 +120,7 @@ jobs:
     env:
       REST_URL: "http://localhost:8080"
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.17.1
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.18.0
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -145,7 +145,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         id: build
         with:
           file: builds/database.Dockerfile
@@ -186,7 +186,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.17.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.18.0
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -222,7 +222,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -230,7 +230,7 @@ jobs:
           run_args: -e POSTGRES_DSN="${POSTGRES_DSN}"
 
   build-standalone-rest:
-    needs: [test-go, build-database]
+    needs: [test-go]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -239,34 +239,17 @@ jobs:
       id-token: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-    services:
-      postgres-narrative-engine:
-        image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    env:
-      POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
+    # This image is booted and exercised by test-pkg-js (a full
+    # integration run), so this job only builds + pushes it. skip_healthcheck
+    # drops the redundant smoke run and the container constellation it needed.
     steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_args: -e POSTGRES_DSN="${POSTGRES_DSN}"
+          skip_healthcheck: true
 
   build-js:
     needs: [test-pkg-js]
@@ -275,7 +258,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.17.1
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.18.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -289,7 +272,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.17.1
+      - uses: a-novel-kit/workflows/go-actions/go-report-card@v1.18.0
         if: github.ref == 'refs/heads/master' && success()
 
   report-codecov:
@@ -298,7 +281,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.17.1
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.18.0
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.17.1
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.18.0
         with:
           release_type: ${{ inputs.release_type }}
           dry_run: ${{ inputs.dry_run }}
@@ -71,7 +71,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
@@ -113,7 +113,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.17.1
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.18.0
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -189,7 +189,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.17.1
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.18.0
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -207,7 +207,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.17.1
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.18.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -228,7 +228,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.17.1
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.18.0
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adopts `a-novel-kit/workflows` **v1.18.0** and passes **`skip_healthcheck: true`** on `build-standalone-rest`, so those jobs only build + push instead of booting a container constellation to smoke-test the image. The smoke test was redundant: **`test-pkg-js`** already boot those same images and run the full integration suite against them. Drops each job's `services`, `env`, `checkout` and `run-migrations`; `release.yaml` keeps its smoke tests (no downstream validator on release) and just moves to v1.18.0.

Same change validated on service-authentication (build-standalone-rest 55s → 23s, total run −13%, green). Part of Epic a-novel/.github#173 (a-novel/.github#172).

## Test plan

- [ ] CI green; the standalone image(s) still built, pushed, and validated by the test job(s)