### PR TITLE
fix(ci): give each Go modfile its own Renovate branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,9 @@
   },
   "packageRules": [
     {
-      "matchManagers": ["gomod"],
-      "matchFileNames": ["!go.mod"],
-      "goGetDirs": ["."]
-    },
-    {
       "matchFileNames": ["golangci-lint.mod"],
+      "additionalBranchPrefix": "golangci-lint-",
+      "goGetDirs": ["."],
       "postUpgradeTasks": {
         "commands": [
           "rm -f golangci-lint.sum",
@@ -25,6 +22,8 @@
     },
     {
       "matchFileNames": ["gotestsum.mod"],
+      "additionalBranchPrefix": "gotestsum-",
+      "goGetDirs": ["."],
       "postUpgradeTasks": {
         "commands": ["rm -f gotestsum.sum", "go get -modfile=gotestsum.mod -tool gotest.tools/gotestsum"],
         "executionMode": "branch"


### PR DESCRIPTION
## Summary

- Gives each Go modfile its own Renovate branch: `additionalBranchPrefix` + `goGetDirs` move onto the per-file rules, and the shared `!go.mod` rule is deleted.
- `goGetDirs: ["."]` is unchanged in value — it is **correct** for the tool modfiles, just relocated so it can no longer reach `go.mod`.

Same change as `a-novel/service-json-keys#842`, which is merged.

## The defect

A Renovate artifact update receives the whole **branch config**, inherited from whichever upgrade sorts first (`config = { ...config, ...config.upgrades[0] }`). A Go bump groups `go.mod` and both tool modfiles into one branch, so a tool modfile sorting first imposes `goGetDirs: ["."]` on `go.mod` — restricting `go get` to the root package, which imports nothing. Only module-graph (`/go.mod h1:`) hashes get written, and every job that compiles fails with `missing go.sum entry`.

It is intermittent because it depends on sort order: on `service-authentication`, #1124 landed green and fully tidied while #1123 landed broken, from identical config on the same day.

`postUpgradeTasks` is resolved the same way and is a non-mergeable `object`, so only **one** rule's tasks run per branch. In an observed run `golangci-lint.mod` was updated twice while `rm -f golangci-lint.sum` ran zero times — which is why `golangci-lint.sum` is incomplete and `pnpm lint:go` cannot run locally.

## Why one branch per modfile

The branch name is `{{branchPrefix}}{{additionalBranchPrefix}}{{branchTopic}}`, and `branchTopic` is the **dependency** — the modfile is not in it. A single shared prefix is therefore not enough: both tool modfiles carry nearly the same dependency graph, so almost every bump would still put two `packageFile`s on one branch. A prefix per modfile is what guarantees one `packageFile` per branch, which makes `upgrades[0]` unambiguous.

Resulting branches:

| branch | scope | effect |
| --- | --- | --- |
| `renovate/<dep>` | default `./...` + `gomodTidy` | complete, tidied `go.sum` |
| `renovate/golangci-lint-<dep>` | `.` + its own sum regeneration | sum actually rebuilt |
| `renovate/gotestsum-<dep>` | `.` + its own sum regeneration | sum actually rebuilt |

Deleting `goGetDirs` instead was tried and rejected — `./...` fails outright on tool modfiles (`cannot find module providing package …/internal/core`). Hoisting `gomodTidy` was rejected too: it would tidy the tool modfiles, pruning `rowserrcheck` and silently disabling a linter.

## Expected first-run diff

The per-tool post-upgrade tasks have never run, so the first `renovate/golangci-lint-…` PR will show a large **deletion** in `golangci-lint.sum` (−124 / +7 measured on `service-json-keys`). That is the corrective backfill finally happening, not a regression.

## Layers changed

- **CI**: `renovate.json` only. No production code.

## Breaking changes

None.

## Test plan

- [x] `renovate.json` is valid JSON and prettier-clean
- [x] `renovate-config-validator` passes (verified meaningful — it rejects a bogus option in the same block)
- [x] `go get -modfile=golangci-lint.mod -t .` exits 0
- [x] `go get -modfile=gotestsum.mod -t .` exits 0
- [ ] **Confirmed live** by the next Renovate Go bump producing one branch per modfile, with the `go.mod` one carrying the module-content hash and green lint/build jobs

The last box cannot be ticked by this PR's own CI — it does not bump a Go module.

Closes #443
