### PR TITLE
feat(migrations): verify reversible migration history

### DIFF
--- a/.github/workflows/approve-pr.yaml
+++ b/.github/workflows/approve-pr.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/approve-pr@v1.27.1
         with:
           pull_request: ${{ inputs.pull_request }}
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}

--- a/.github/workflows/auto-approve-dependabot.yaml
+++ b/.github/workflows/auto-approve-dependabot.yaml
@@ -20,7 +20,7 @@ jobs:
     # the callee mints a scoped App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/auto-approve-dependabot-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       dependency_bot_login: ${{ vars.DEPENDENCY_BOT_LOGIN }}

--- a/.github/workflows/auto-assign-author.yaml
+++ b/.github/workflows/auto-assign-author.yaml
@@ -10,6 +10,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/assign-bot@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/derive-status.yaml
+++ b/.github/workflows/derive-status.yaml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: read
       issues: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/derive-status@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-freeze.yaml
+++ b/.github/workflows/epic-freeze.yaml
@@ -33,7 +33,7 @@ jobs:
     # a stray forward is sweep-only, so a per-PR run can never re-enqueue.
     permissions: {}
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/detect-partial-landing@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/epic-rollback.yaml
+++ b/.github/workflows/epic-rollback.yaml
@@ -52,7 +52,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/epic-rollback-run.yaml@v1.27.1
     with:
       epic_number: ${{ inputs.epic_number }}
       confirm: ${{ inputs.confirm }}

--- a/.github/workflows/hotfix.yaml
+++ b/.github/workflows/hotfix.yaml
@@ -51,7 +51,7 @@ jobs:
     permissions:
       contents: write
       actions: read
-    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/hotfix-run.yaml@v1.27.1
     with:
       line: ${{ inputs.line }}
       fix_ref: ${{ inputs.fix_ref }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,13 +5,50 @@ on:
     tags-ignore:
       - "**"
     branches:
-      - "**"
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  merge_group:
 
 jobs:
-  generated-go:
+  check-migration-snapshots:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+        with:
+          path: internal/models/migrations/testdata/schema
+          base: ${{ github.event.pull_request.base.sha }}
+
+  generated-go:
+    needs: [build-database]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
+        ports:
+          - "5432:5432"
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
       - uses: actions/checkout@v7
         with:
@@ -22,7 +59,7 @@ jobs:
       - name: go generate
         shell: bash
         run: go generate ./...
-      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/check-changes@v1.27.1
         with:
           fail_message: go generate definitions are not up-to-date, please run 'go generate ./...' and commit the changes
 
@@ -31,7 +68,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.26.2
+      - uses: a-novel-kit/workflows/go-actions/lint-go@v1.27.1
 
   lint-node:
     runs-on: ubuntu-latest
@@ -39,7 +76,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/lint-node@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -54,7 +91,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/lint-shell@v1.27.1
         with:
           # renovate: datasource=github-releases depName=koalaman/shellcheck
           version: "0.11.0"
@@ -67,7 +104,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/lint-dockerfile@v1.27.1
         with:
           # renovate: datasource=github-releases depName=hadolint/hadolint
           version: "2.14.0"
@@ -81,7 +118,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/lint-semgrep@v1.27.1
         with:
           ruleset: service
           # renovate: datasource=docker depName=semgrep/semgrep
@@ -97,7 +134,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/scan-secrets@v1.27.1
         with:
           # renovate: datasource=github-releases depName=gitleaks/gitleaks
           version: "8.30.1"
@@ -112,7 +149,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
-      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.26.2
+      - uses: a-novel-kit/workflows/security-actions/lint-workflows@v1.27.1
         with:
           # renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
           version: "1.28.0"
@@ -147,7 +184,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/go-actions/test-go@v1.26.2
+      - uses: a-novel-kit/workflows/go-actions/test-go@v1.27.1
         id: test
         with:
           filter_extra_patterns: "| grep /internal"
@@ -233,7 +270,7 @@ jobs:
     env:
       REST_URL: "http://localhost:8080"
     steps:
-      - uses: a-novel-kit/workflows/node-actions/test-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/test-node@v1.27.1
         id: test
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -258,7 +295,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         id: build
         with:
           file: builds/database.Dockerfile
@@ -299,7 +336,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -337,7 +374,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -357,7 +394,7 @@ jobs:
     # integration run), so this job only builds + pushes it. skip_healthcheck
     # drops the redundant smoke run and the container constellation it needed.
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         id: build
         with:
           file: builds/standalone.rest.Dockerfile
@@ -371,7 +408,7 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/build-node@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/build-node@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.DEPENDENCY_BOT_PRIVATE_KEY }}
@@ -384,7 +421,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/codecov@v1.27.1
         with:
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
           coverage_files: coverage.txt,coverage/*

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -34,7 +34,7 @@ jobs:
     # the callee mints its own App token and declares permissions: {}; the caller sets the ceiling, so it must not hand down
     # the repository default.
     permissions: {}
-    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/merge-gate-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       kill_switch: ${{ vars.AGENT_KILL_SWITCH }}

--- a/.github/workflows/node-audit.yaml
+++ b/.github/workflows/node-audit.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
       packages: read
     steps:
-      - uses: a-novel-kit/workflows/node-actions/audit@v1.26.2
+      - uses: a-novel-kit/workflows/node-actions/audit@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-train.yaml
+++ b/.github/workflows/release-train.yaml
@@ -39,7 +39,7 @@ jobs:
     # the repository default.
     permissions:
       contents: read
-    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.26.2
+    uses: a-novel-kit/workflows/.github/workflows/release-train-run.yaml@v1.27.1
     with:
       client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
       epic_number: ${{ inputs.epic_number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
       tag: ${{ steps.core.outputs.tag }}
     steps:
       - id: core
-        uses: a-novel-kit/workflows/publish-actions/release-core@v1.26.2
+        uses: a-novel-kit/workflows/publish-actions/release-core@v1.27.1
         with:
           # renovate: datasource=go depName=github.com/a-novel-kit/stack/cli
           cli_version: "1.7.5"
@@ -73,7 +73,7 @@ jobs:
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/database.Dockerfile
           image_name: ${{ github.repository }}/database
@@ -115,7 +115,7 @@ jobs:
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
-      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker-job@v1.27.1
         with:
           file: builds/migrations.Dockerfile
           image_name: ${{ github.repository }}/jobs/migrations
@@ -155,7 +155,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/rest.Dockerfile
           image_name: ${{ github.repository }}/rest
@@ -195,7 +195,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-migrations
-      - uses: a-novel-kit/workflows/build-actions/docker@v1.26.2
+      - uses: a-novel-kit/workflows/build-actions/docker@v1.27.1
         with:
           file: builds/standalone.rest.Dockerfile
           image_name: ${{ github.repository }}/standalone-rest
@@ -213,7 +213,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: a-novel-kit/workflows/publish-actions/npm@v1.26.2
+      - uses: a-novel-kit/workflows/publish-actions/npm@v1.27.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           app_private_key: ${{ secrets.PUBLISH_BOT_PRIVATE_KEY }}
@@ -234,7 +234,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/archive-board-items@v1.27.1
         with:
           client_id: ${{ vars.AGENT_BOT_CLIENT_ID }}
           app_private_key: ${{ secrets.AGENT_BOT_PRIVATE_KEY }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       security-events: read
     steps:
-      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.26.2
+      - uses: a-novel-kit/workflows/generic-actions/renovate@v1.27.1
         with:
           allowed_commands: |
             [

--- a/internal/models/migrations/migrations.go
+++ b/internal/models/migrations/migrations.go
@@ -10,5 +10,6 @@ import (
 // bring a database up to the service's current schema. Each timestamped file has an .up.sql step to
 // apply the change and a matching .down.sql step to revert it.
 //
+//go:generate env GOLIB_UPDATE_SNAPSHOTS=1 go test -run ^TestMigrationRoundtrip$
 //go:embed *.sql
 var Migrations embed.FS

--- a/internal/models/migrations/migrations_test.go
+++ b/internal/models/migrations/migrations_test.go
@@ -1,0 +1,27 @@
+package migrations_test
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel-kit/golib/postgres"
+
+	"github.com/a-novel/service-narrative-engine/internal/config/configtest"
+	"github.com/a-novel/service-narrative-engine/internal/models/migrations"
+)
+
+func TestMigrationRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	_, err := fs.Stat(migrations.Migrations, "testdata")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+
+	postgres.RunMigrationRoundtripTest(t, configtest.PostgresPreset, migrations.Migrations,
+		&postgres.RoundtripOptions{
+			Fixtures:  os.DirFS("testdata/fixtures"),
+			Snapshots: "testdata/schema",
+		})
+}

--- a/internal/models/migrations/testdata/fixtures/20250306000000_items_table.sql
+++ b/internal/models/migrations/testdata/fixtures/20250306000000_items_table.sql
@@ -1,0 +1,9 @@
+-- A fixture runs after its matching migration and seeds data for the next migration.
+INSERT INTO
+  items (id, name, description)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000001',
+    'fixture item',
+    'survives the next migration'
+  );

--- a/internal/models/migrations/testdata/schema/20250306000000_items_table.txt
+++ b/internal/models/migrations/testdata/schema/20250306000000_items_table.txt
@@ -1,0 +1,16 @@
+column	items.created_at	timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+column	items.description	text
+column	items.id	uuid NOT NULL DEFAULT gen_random_uuid()
+column	items.name	text NOT NULL
+column	items.updated_at	timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
+comment	schema public	standard public schema
+constraint	items.items_created_at_not_null	NOT NULL created_at
+constraint	items.items_id_not_null	NOT NULL id
+constraint	items.items_name_check	CHECK ((name <> ''::text))
+constraint	items.items_name_not_null	NOT NULL name
+constraint	items.items_pkey	PRIMARY KEY (id)
+constraint	items.items_updated_at_not_null	NOT NULL updated_at
+extension	plpgsql	1.0
+index	items_pkey	CREATE UNIQUE INDEX items_pkey ON public.items USING btree (id)
+relation	items	r
+schema	public	pg_database_owner=UC/pg_database_owner,=U/pg_database_owner


### PR DESCRIPTION
## Summary

- verify the items migration through forward, fixture, rollback, and replay cycles
- keep the baseline byte-identical to the service template
- record an append-only schema snapshot and run generation against the built database image

## Breaking changes

None.

## Test plan

- [x] migration roundtrip test on PostgreSQL 18
- [x] deterministic snapshot regeneration
- [x] `pnpm lint:ci` and `pnpm lint:go`
- [x] `a-novel test --type=go -y`
- [x] `a-novel build --type=go -y`

Closes #481.
Part of a-novel/.github#237.