### PR TITLE
feat(migrations): freeze migration history

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,9 +21,15 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+      - name: Check schema snapshots
+        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
         with:
           path: internal/models/migrations/testdata/schema
+          base: ${{ github.event.pull_request.base.sha }}
+      - name: Check migration SQL
+        uses: a-novel-kit/workflows/generic-actions/check-append-only@v1.27.1
+        with:
+          path: ":(glob)internal/models/migrations/*.sql"
           base: ${{ github.event.pull_request.base.sha }}
 
   generated-go:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/a-novel/service-narrative-engine
 go 1.26.5
 
 require (
-	github.com/a-novel-kit/golib v0.30.0
+	github.com/a-novel-kit/golib v0.30.1
 	github.com/a-novel/service-authentication/v2 v2.4.5
 	github.com/a-novel/service-jobs v0.2.1
 	github.com/a-novel/service-json-keys/v2 v2.4.1

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.59.0/go.mod h1:YqwkQPrWSC7+byyc1VlKbWLBF5JsW5IoL6xUkemYSXk=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.59.0 h1:qkIrO8aDwTenWjMRObvOwx8XFnrHR4nO8rHhigtE+3M=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.59.0/go.mod h1:gW2WKecnAdBKF4E64jL86UXyvVcsPnNunINOq72OLMk=
-github.com/a-novel-kit/golib v0.30.0 h1:/7SokOlBytGcFR4WvAEd5emtLOSPpWqgQ4HDJdyckOs=
-github.com/a-novel-kit/golib v0.30.0/go.mod h1:zB3qDKe78ITgLDWFp0KNv7q1WSYPqof2m+XqwQSYbkY=
+github.com/a-novel-kit/golib v0.30.1 h1:/BaRbqsnGUY/aCQ6zEkeiRVOQWLLisXKRiby6cYFF2U=
+github.com/a-novel-kit/golib v0.30.1/go.mod h1:zB3qDKe78ITgLDWFp0KNv7q1WSYPqof2m+XqwQSYbkY=
 github.com/a-novel-kit/jwt/v2 v2.2.1 h1:Oqu29DG6k9/v3Eo3uLpYPCGP1c8xp4cFcjaVlUpR4oM=
 github.com/a-novel-kit/jwt/v2 v2.2.1/go.mod h1:QLLGdh58mLRNb0SiRCrYww2EJrdyaMSVKPn3jovPEQg=
 github.com/a-novel/service-authentication/v2 v2.4.5 h1:+I42jKAig3B7/Hh/dumT+Vae++Q9DiVgyBsf2xgw/ek=

--- a/internal/models/migrations/testdata/schema/20250306000000_items_table.txt
+++ b/internal/models/migrations/testdata/schema/20250306000000_items_table.txt
@@ -1,3 +1,4 @@
+migration-history	sha256:c933f9b619f376e820a51e916ceb93e908f8ed7e6ae3d6cbbe7b841966aba544
 column	items.created_at	timestamp with time zone NOT NULL DEFAULT CURRENT_TIMESTAMP
 column	items.description	text
 column	items.id	uuid NOT NULL DEFAULT gen_random_uuid()


### PR DESCRIPTION
## Summary

- pin golib v0.30.1 and regenerate every schema golden with its cumulative migration-history digest
- reject edits to landed top-level migration SQL through the existing append-only CI action
- use the reviewed `append-only-override` label only for this one-time golden regeneration

## Layers changed

- **Migrations**: bind committed schema goldens to the exact up/down SQL history
- **CI**: apply the existing append-only gate to migration SQL without adding a new required job
- **Dependencies**: update golib from v0.30.0 to v0.30.1

## Breaking changes

None.

## Test plan

- [x] `pnpm generate:go`
- [x] `pnpm lint:stylecheck`
- [x] `pnpm lint:go`
- [x] `a-novel build --type=go -y`
- [x] `a-novel test --type=go -y`

Closes #486