### PR TITLE
feat(handlers): protect item routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,10 @@ pnpm add @a-novel/service-narrative-engine-rest
 import { NarrativeEngineApi, itemCreate, itemList } from "@a-novel/service-narrative-engine-rest";
 
 const api = new NarrativeEngineApi("http://service-narrative-engine:8080");
+const accessToken = "<access-token>";
 
-const created = await itemCreate(api, "My Item", "An optional description.");
-const items = await itemList(api, 10, 0);
+const created = await itemCreate(api, accessToken, "My Item", "An optional description.");
+const items = await itemList(api, accessToken, 10, 0);
 ```
 
 API reference: [a-novel.github.io/service-narrative-engine](https://a-novel.github.io/service-narrative-engine).

--- a/cmd/rest/main.go
+++ b/cmd/rest/main.go
@@ -83,8 +83,6 @@ func main() {
 		servicejsonkeys.NewClaimsVerifier[serviceauthentication.Claims](jsonKeysClient),
 	)
 	withAuth := serviceauthentication.NewAuthHandler(claimsVerifier, cfg.Permissions, cfg.Logger)
-	// Protected routes receive this wrapper once their handlers carry authenticated actors.
-	_ = withAuth
 
 	// =================================================================================================================
 	// DAO
@@ -146,11 +144,17 @@ func main() {
 
 	router.Get("/ping", handlerPing.ServeHTTP)
 	router.Get("/healthcheck", handlerHealth.ServeHTTP)
-	router.Post("/items", handlerItemCreate.ServeHTTP)
-	router.Get("/items", handlerItemList.ServeHTTP)
-	router.Get("/item", handlerItemGet.ServeHTTP)
-	router.Put("/item", handlerItemUpdate.ServeHTTP)
-	router.Delete("/item", handlerItemDelete.ServeHTTP)
+	router.Route("/items", func(r chi.Router) {
+		r.Use(handlers.BearerChallenge)
+		withAuth(r, config.PermissionItemWrite).Post("/", handlerItemCreate.ServeHTTP)
+		withAuth(r, config.PermissionItemRead).Get("/", handlerItemList.ServeHTTP)
+	})
+	router.Route("/item", func(r chi.Router) {
+		r.Use(handlers.BearerChallenge)
+		withAuth(r, config.PermissionItemRead).Get("/", handlerItemGet.ServeHTTP)
+		withAuth(r, config.PermissionItemWrite).Put("/", handlerItemUpdate.ServeHTTP)
+		withAuth(r, config.PermissionItemWrite).Delete("/", handlerItemDelete.ServeHTTP)
+	})
 
 	// =================================================================================================================
 	// RUN

--- a/internal/core/actor.go
+++ b/internal/core/actor.go
@@ -1,0 +1,11 @@
+package core
+
+import "github.com/google/uuid"
+
+// Actor is the authenticated identity a request acts on behalf of.
+// Authorization remains at the handler boundary and is not carried here.
+type Actor struct {
+	// UserID is the authenticated user. Anonymous actors are rejected before
+	// entering the service layer.
+	UserID uuid.UUID `validate:"required"`
+}

--- a/internal/core/actor_test.go
+++ b/internal/core/actor_test.go
@@ -1,0 +1,9 @@
+package core_test
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/a-novel/service-narrative-engine/internal/core"
+)
+
+var testActor = core.Actor{UserID: uuid.MustParse("00000000-0000-0000-0000-000000000042")}

--- a/internal/core/itemCreate.go
+++ b/internal/core/itemCreate.go
@@ -22,6 +22,7 @@ type ItemCreateDao interface {
 
 // ItemCreateRequest holds the validated input for [ItemCreate.Exec].
 type ItemCreateRequest struct {
+	Actor       Actor  `validate:"required"`
 	Name        string `validate:"required,notblank,max=256"`
 	Description string `validate:"max=1024"`
 }

--- a/internal/core/itemCreate_test.go
+++ b/internal/core/itemCreate_test.go
@@ -39,6 +39,7 @@ func TestItemCreate(t *testing.T) {
 			name: "Success",
 
 			request: &core.ItemCreateRequest{
+				Actor:       testActor,
 				Name:        "test item",
 				Description: "test description",
 			},
@@ -62,27 +63,33 @@ func TestItemCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "Error/MissingActor",
+
+			request:   &core.ItemCreateRequest{Name: "test item"},
+			expectErr: core.ErrInvalidRequest,
+		},
+		{
 			name: "Error/EmptyName",
 
-			request:   &core.ItemCreateRequest{Name: ""},
+			request:   &core.ItemCreateRequest{Actor: testActor, Name: ""},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/WhitespaceOnlyName",
 
-			request:   &core.ItemCreateRequest{Name: "   "},
+			request:   &core.ItemCreateRequest{Actor: testActor, Name: "   "},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/NameTooLong",
 
-			request:   &core.ItemCreateRequest{Name: string(make([]byte, 257))},
+			request:   &core.ItemCreateRequest{Actor: testActor, Name: string(make([]byte, 257))},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/Dao",
 
-			request: &core.ItemCreateRequest{Name: "test item"},
+			request: &core.ItemCreateRequest{Actor: testActor, Name: "test item"},
 
 			daoMock:   &daoMock{err: errFoo},
 			expectErr: errFoo,

--- a/internal/core/itemDelete.go
+++ b/internal/core/itemDelete.go
@@ -20,6 +20,7 @@ type ItemDeleteDao interface {
 
 // ItemDeleteRequest identifies the item to remove.
 type ItemDeleteRequest struct {
+	Actor Actor `validate:"required"`
 	// ID of the item. uuid.Nil is rejected as an unset identifier, usually a
 	// missing request parameter.
 	ID uuid.UUID `validate:"required"`

--- a/internal/core/itemDelete_test.go
+++ b/internal/core/itemDelete_test.go
@@ -38,7 +38,8 @@ func TestItemDelete(t *testing.T) {
 			name: "Success",
 
 			request: &core.ItemDeleteRequest{
-				ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Actor: testActor,
+				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 			},
 
 			daoMock: &daoMock{
@@ -60,16 +61,25 @@ func TestItemDelete(t *testing.T) {
 			},
 		},
 		{
+			name: "Error/MissingActor",
+
+			request: &core.ItemDeleteRequest{
+				ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			},
+			expectErr: core.ErrInvalidRequest,
+		},
+		{
 			name: "Error/InvalidID",
 
-			request:   &core.ItemDeleteRequest{ID: uuid.Nil},
+			request:   &core.ItemDeleteRequest{Actor: testActor, ID: uuid.Nil},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/Dao",
 
 			request: &core.ItemDeleteRequest{
-				ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Actor: testActor,
+				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 			},
 
 			daoMock:   &daoMock{err: errFoo},

--- a/internal/core/itemGet.go
+++ b/internal/core/itemGet.go
@@ -20,6 +20,7 @@ type ItemGetDao interface {
 
 // ItemGetRequest identifies the item to fetch.
 type ItemGetRequest struct {
+	Actor Actor `validate:"required"`
 	// ID of the item. uuid.Nil is rejected as an unset identifier, usually a
 	// missing request parameter.
 	ID uuid.UUID `validate:"required"`

--- a/internal/core/itemGet_test.go
+++ b/internal/core/itemGet_test.go
@@ -38,7 +38,8 @@ func TestItemGet(t *testing.T) {
 			name: "Success",
 
 			request: &core.ItemGetRequest{
-				ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Actor: testActor,
+				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 			},
 
 			daoMock: &daoMock{
@@ -60,16 +61,25 @@ func TestItemGet(t *testing.T) {
 			},
 		},
 		{
+			name: "Error/MissingActor",
+
+			request: &core.ItemGetRequest{
+				ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+			},
+			expectErr: core.ErrInvalidRequest,
+		},
+		{
 			name: "Error/InvalidID",
 
-			request:   &core.ItemGetRequest{ID: uuid.Nil},
+			request:   &core.ItemGetRequest{Actor: testActor, ID: uuid.Nil},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/Dao",
 
 			request: &core.ItemGetRequest{
-				ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Actor: testActor,
+				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 			},
 
 			daoMock:   &daoMock{err: errFoo},

--- a/internal/core/itemList.go
+++ b/internal/core/itemList.go
@@ -28,6 +28,7 @@ const (
 
 // ItemListRequest selects a page of items.
 type ItemListRequest struct {
+	Actor Actor `validate:"required"`
 	// Limit defaults to ItemListDefaultSize when zero or negative.
 	Limit  int `validate:"max=100"`
 	Offset int `validate:"min=0"`

--- a/internal/core/itemList_test.go
+++ b/internal/core/itemList_test.go
@@ -37,7 +37,7 @@ func TestItemList(t *testing.T) {
 		{
 			name: "Success",
 
-			request: &core.ItemListRequest{Limit: 10, Offset: 0},
+			request: &core.ItemListRequest{Actor: testActor, Limit: 10, Offset: 0},
 
 			daoMock: &daoMock{
 				resp: []*dao.Item{
@@ -74,7 +74,7 @@ func TestItemList(t *testing.T) {
 		{
 			name: "Success/Empty",
 
-			request: &core.ItemListRequest{Limit: 10, Offset: 0},
+			request: &core.ItemListRequest{Actor: testActor, Limit: 10, Offset: 0},
 
 			daoMock: &daoMock{resp: []*dao.Item{}},
 
@@ -83,28 +83,34 @@ func TestItemList(t *testing.T) {
 		{
 			name: "Success/LimitDefaulted",
 
-			request: &core.ItemListRequest{Limit: 0, Offset: 0},
+			request: &core.ItemListRequest{Actor: testActor, Limit: 0, Offset: 0},
 
 			daoMock: &daoMock{resp: []*dao.Item{}},
 
 			expect: []*core.Item{},
 		},
 		{
+			name: "Error/MissingActor",
+
+			request:   &core.ItemListRequest{Limit: 10, Offset: 0},
+			expectErr: core.ErrInvalidRequest,
+		},
+		{
 			name: "Error/LimitTooHigh",
 
-			request:   &core.ItemListRequest{Limit: 101, Offset: 0},
+			request:   &core.ItemListRequest{Actor: testActor, Limit: 101, Offset: 0},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/OffsetNegative",
 
-			request:   &core.ItemListRequest{Limit: 10, Offset: -1},
+			request:   &core.ItemListRequest{Actor: testActor, Limit: 10, Offset: -1},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/Dao",
 
-			request: &core.ItemListRequest{Limit: 10, Offset: 0},
+			request: &core.ItemListRequest{Actor: testActor, Limit: 10, Offset: 0},
 
 			daoMock:   &daoMock{err: errFoo},
 			expectErr: errFoo,

--- a/internal/core/itemUpdate.go
+++ b/internal/core/itemUpdate.go
@@ -23,6 +23,7 @@ type ItemUpdateDao interface {
 // ItemUpdateRequest holds the validated input for [ItemUpdate.Exec]; ID selects
 // the item to modify.
 type ItemUpdateRequest struct {
+	Actor       Actor `validate:"required"`
 	ID          uuid.UUID
 	Name        string `validate:"required,notblank,max=256"`
 	Description string `validate:"max=1024"`

--- a/internal/core/itemUpdate_test.go
+++ b/internal/core/itemUpdate_test.go
@@ -39,6 +39,7 @@ func TestItemUpdate(t *testing.T) {
 			name: "Success",
 
 			request: &core.ItemUpdateRequest{
+				Actor:       testActor,
 				ID:          uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				Name:        "updated item",
 				Description: "updated description",
@@ -63,23 +64,41 @@ func TestItemUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "Error/MissingActor",
+
+			request: &core.ItemUpdateRequest{
+				ID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name: "updated item",
+			},
+			expectErr: core.ErrInvalidRequest,
+		},
+		{
 			name: "Error/EmptyName",
 
-			request:   &core.ItemUpdateRequest{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), Name: ""},
+			request: &core.ItemUpdateRequest{
+				Actor: testActor,
+				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:  "",
+			},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/WhitespaceOnlyName",
 
-			request:   &core.ItemUpdateRequest{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), Name: "   "},
+			request: &core.ItemUpdateRequest{
+				Actor: testActor,
+				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:  "   ",
+			},
 			expectErr: core.ErrInvalidRequest,
 		},
 		{
 			name: "Error/NameTooLong",
 
 			request: &core.ItemUpdateRequest{
-				ID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-				Name: string(make([]byte, 257)),
+				Actor: testActor,
+				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:  string(make([]byte, 257)),
 			},
 			expectErr: core.ErrInvalidRequest,
 		},
@@ -87,8 +106,9 @@ func TestItemUpdate(t *testing.T) {
 			name: "Error/Dao",
 
 			request: &core.ItemUpdateRequest{
-				ID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-				Name: "updated item",
+				Actor: testActor,
+				ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+				Name:  "updated item",
 			},
 
 			daoMock:   &daoMock{err: errFoo},

--- a/internal/handlers/http.actor.go
+++ b/internal/handlers/http.actor.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	serviceauthentication "github.com/a-novel/service-authentication/v2/pkg/go"
+
+	"github.com/a-novel-kit/golib/otel"
+
+	"github.com/a-novel/service-narrative-engine/internal/core"
+)
+
+// ErrAnonymousActor means authenticated claims do not identify a user.
+var ErrAnonymousActor = errors.New("anonymous actor")
+
+func actorFromContext(ctx context.Context) (*core.Actor, error) {
+	ctx, span := otel.Tracer().Start(ctx, "rest.ActorFromContext")
+	defer span.End()
+
+	claims, err := serviceauthentication.MustGetClaimsContext(ctx)
+	if err != nil {
+		return nil, otel.ReportError(span, fmt.Errorf("get actor claims: %w", err))
+	}
+
+	if claims.UserID == nil {
+		return nil, otel.ReportError(span, ErrAnonymousActor)
+	}
+
+	return otel.ReportSuccess(span, &core.Actor{UserID: *claims.UserID}), nil
+}

--- a/internal/handlers/http.actor_test.go
+++ b/internal/handlers/http.actor_test.go
@@ -1,0 +1,34 @@
+package handlers_test
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+
+	serviceauthentication "github.com/a-novel/service-authentication/v2/pkg/go"
+
+	"github.com/a-novel/service-narrative-engine/internal/core"
+)
+
+type testClaimsState uint8
+
+const (
+	testClaimsValid testClaimsState = iota
+	testClaimsAnonymous
+	testClaimsMissing
+)
+
+var testActor = core.Actor{UserID: uuid.MustParse("00000000-0000-0000-0000-000000000042")}
+
+func withTestClaims(request *http.Request, state testClaimsState) *http.Request {
+	if state == testClaimsMissing {
+		return request
+	}
+
+	claims := &serviceauthentication.Claims{}
+	if state == testClaimsValid {
+		claims.UserID = &testActor.UserID
+	}
+
+	return request.WithContext(serviceauthentication.SetClaimsContext(request.Context(), claims))
+}

--- a/internal/handlers/http.bearerChallenge.go
+++ b/internal/handlers/http.bearerChallenge.go
@@ -1,0 +1,25 @@
+package handlers
+
+import "net/http"
+
+// #nosec G101 -- This is an HTTP authentication challenge, not a credential.
+const bearerChallenge = `Bearer realm="narrative-engine", error="invalid_token"`
+
+type challengeWriter struct {
+	http.ResponseWriter
+}
+
+func (writer *challengeWriter) WriteHeader(status int) {
+	if status == http.StatusUnauthorized {
+		writer.Header().Set("WWW-Authenticate", bearerChallenge)
+	}
+
+	writer.ResponseWriter.WriteHeader(status)
+}
+
+// BearerChallenge adds the RFC 6750 challenge to unauthorized responses.
+func BearerChallenge(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(&challengeWriter{ResponseWriter: w}, r)
+	})
+}

--- a/internal/handlers/http.bearerChallenge_test.go
+++ b/internal/handlers/http.bearerChallenge_test.go
@@ -1,0 +1,46 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/a-novel/service-narrative-engine/internal/handlers"
+)
+
+func TestBearerChallenge(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		status          int
+		expectChallenge string
+	}{
+		{
+			name:            "Unauthorized",
+			status:          http.StatusUnauthorized,
+			expectChallenge: `Bearer realm="narrative-engine", error="invalid_token"`,
+		},
+		{name: "Forbidden", status: http.StatusForbidden},
+		{name: "Success", status: http.StatusOK},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := httptest.NewRecorder()
+			request := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items", nil)
+			handler := handlers.BearerChallenge(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(testCase.status)
+			}))
+
+			handler.ServeHTTP(w, request)
+
+			require.Equal(t, testCase.status, w.Code)
+			require.Equal(t, testCase.expectChallenge, w.Header().Get("WWW-Authenticate"))
+		})
+	}
+}

--- a/internal/handlers/http.itemCreatePublic.go
+++ b/internal/handlers/http.itemCreatePublic.go
@@ -38,11 +38,20 @@ func (handler *ItemCreatePublic) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	ctx, span := otel.Tracer().Start(r.Context(), "rest.ItemCreatePublic")
 	defer span.End()
 
+	actor, err := actorFromContext(ctx)
+	if err != nil {
+		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
+			ErrAnonymousActor: http.StatusForbidden,
+		}, err)
+
+		return
+	}
+
 	decoder := json.NewDecoder(r.Body)
 
 	var request ItemCreatePublicRequest
 
-	err := decoder.Decode(&request)
+	err = decoder.Decode(&request)
 	if err != nil {
 		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{nil: http.StatusBadRequest}, err)
 
@@ -50,6 +59,7 @@ func (handler *ItemCreatePublic) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	item, err := handler.service.Exec(ctx, &core.ItemCreateRequest{
+		Actor:       *actor,
 		Name:        request.Name,
 		Description: request.Description,
 	})

--- a/internal/handlers/http.itemCreatePublic_test.go
+++ b/internal/handlers/http.itemCreatePublic_test.go
@@ -35,6 +35,7 @@ func TestRestItemCreatePublic(t *testing.T) {
 		name string
 
 		request *http.Request
+		claims  testClaimsState
 
 		serviceMock *serviceMock
 
@@ -51,6 +52,7 @@ func TestRestItemCreatePublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemCreateRequest{
+					Actor:       testActor,
 					Name:        "test item",
 					Description: "test description",
 				},
@@ -73,6 +75,20 @@ func TestRestItemCreatePublic(t *testing.T) {
 			},
 		},
 		{
+			name: "Error/AnonymousActor",
+
+			request:      httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/items", strings.NewReader(`{}`)),
+			claims:       testClaimsAnonymous,
+			expectStatus: http.StatusForbidden,
+		},
+		{
+			name: "Error/MissingClaims",
+
+			request:      httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/items", strings.NewReader(`{}`)),
+			claims:       testClaimsMissing,
+			expectStatus: http.StatusInternalServerError,
+		},
+		{
 			name: "Error/InvalidBody",
 
 			request: httptest.NewRequestWithContext(t.Context(), http.MethodPost, "/items", strings.NewReader(`not json`)),
@@ -87,7 +103,7 @@ func TestRestItemCreatePublic(t *testing.T) {
 			}`)),
 
 			serviceMock: &serviceMock{
-				req: &core.ItemCreateRequest{Name: ""},
+				req: &core.ItemCreateRequest{Actor: testActor, Name: ""},
 				err: core.ErrInvalidRequest,
 			},
 
@@ -101,7 +117,7 @@ func TestRestItemCreatePublic(t *testing.T) {
 			}`)),
 
 			serviceMock: &serviceMock{
-				req: &core.ItemCreateRequest{Name: "test item"},
+				req: &core.ItemCreateRequest{Actor: testActor, Name: "test item"},
 				err: errFoo,
 			},
 
@@ -124,7 +140,7 @@ func TestRestItemCreatePublic(t *testing.T) {
 			handler := handlers.NewItemCreatePublic(service, config.LoggerDev)
 			w := httptest.NewRecorder()
 
-			handler.ServeHTTP(w, testCase.request)
+			handler.ServeHTTP(w, withTestClaims(testCase.request, testCase.claims))
 
 			res := w.Result()
 

--- a/internal/handlers/http.itemDeletePublic.go
+++ b/internal/handlers/http.itemDeletePublic.go
@@ -40,16 +40,25 @@ func (handler *ItemDeletePublic) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	ctx, span := otel.Tracer().Start(r.Context(), "rest.ItemDeletePublic")
 	defer span.End()
 
+	actor, err := actorFromContext(ctx)
+	if err != nil {
+		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
+			ErrAnonymousActor: http.StatusForbidden,
+		}, err)
+
+		return
+	}
+
 	var request ItemDeletePublicRequest
 
-	err := muxDecoder.Decode(&request, r.URL.Query())
+	err = muxDecoder.Decode(&request, r.URL.Query())
 	if err != nil {
 		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{nil: http.StatusBadRequest}, err)
 
 		return
 	}
 
-	item, err := handler.service.Exec(ctx, &core.ItemDeleteRequest{ID: request.ID})
+	item, err := handler.service.Exec(ctx, &core.ItemDeleteRequest{Actor: *actor, ID: request.ID})
 	if err != nil {
 		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
 			dao.ErrItemDeleteNotFound: http.StatusNotFound,

--- a/internal/handlers/http.itemDeletePublic_test.go
+++ b/internal/handlers/http.itemDeletePublic_test.go
@@ -35,6 +35,7 @@ func TestRestItemDeletePublic(t *testing.T) {
 		name string
 
 		request *http.Request
+		claims  testClaimsState
 
 		serviceMock *serviceMock
 
@@ -53,7 +54,8 @@ func TestRestItemDeletePublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemDeleteRequest{
-					ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 				resp: &core.Item{
 					ID:          uuid.MustParse("00000000-0000-0000-0000-000000000001"),
@@ -72,6 +74,26 @@ func TestRestItemDeletePublic(t *testing.T) {
 				"createdAt":   "2021-01-01T00:00:00Z",
 				"updatedAt":   "2021-01-01T00:00:00Z",
 			},
+		},
+		{
+			name: "Error/AnonymousActor",
+
+			request: httptest.NewRequestWithContext(
+				t.Context(), http.MethodDelete, "/item?id=00000000-0000-0000-0000-000000000001", nil,
+			),
+			claims: testClaimsAnonymous,
+
+			expectStatus: http.StatusForbidden,
+		},
+		{
+			name: "Error/MissingClaims",
+
+			request: httptest.NewRequestWithContext(
+				t.Context(), http.MethodDelete, "/item?id=00000000-0000-0000-0000-000000000001", nil,
+			),
+			claims: testClaimsMissing,
+
+			expectStatus: http.StatusInternalServerError,
 		},
 		{
 			name: "Error/InvalidID",
@@ -97,7 +119,8 @@ func TestRestItemDeletePublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemDeleteRequest{
-					ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 				err: dao.ErrItemDeleteNotFound,
 			},
@@ -116,7 +139,8 @@ func TestRestItemDeletePublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemDeleteRequest{
-					ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 				err: errFoo,
 			},
@@ -140,7 +164,7 @@ func TestRestItemDeletePublic(t *testing.T) {
 			handler := handlers.NewItemDeletePublic(service, config.LoggerDev)
 			w := httptest.NewRecorder()
 
-			handler.ServeHTTP(w, testCase.request)
+			handler.ServeHTTP(w, withTestClaims(testCase.request, testCase.claims))
 
 			res := w.Result()
 

--- a/internal/handlers/http.itemGetPublic.go
+++ b/internal/handlers/http.itemGetPublic.go
@@ -39,16 +39,25 @@ func (handler *ItemGetPublic) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 	ctx, span := otel.Tracer().Start(r.Context(), "rest.ItemGetPublic")
 	defer span.End()
 
+	actor, err := actorFromContext(ctx)
+	if err != nil {
+		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
+			ErrAnonymousActor: http.StatusForbidden,
+		}, err)
+
+		return
+	}
+
 	var request ItemGetPublicRequest
 
-	err := muxDecoder.Decode(&request, r.URL.Query())
+	err = muxDecoder.Decode(&request, r.URL.Query())
 	if err != nil {
 		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{nil: http.StatusBadRequest}, err)
 
 		return
 	}
 
-	item, err := handler.service.Exec(ctx, &core.ItemGetRequest{ID: request.ID})
+	item, err := handler.service.Exec(ctx, &core.ItemGetRequest{Actor: *actor, ID: request.ID})
 	if err != nil {
 		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
 			dao.ErrItemGetNotFound: http.StatusNotFound,

--- a/internal/handlers/http.itemGetPublic_test.go
+++ b/internal/handlers/http.itemGetPublic_test.go
@@ -35,6 +35,7 @@ func TestRestItemGetPublic(t *testing.T) {
 		name string
 
 		request *http.Request
+		claims  testClaimsState
 
 		serviceMock *serviceMock
 
@@ -53,7 +54,8 @@ func TestRestItemGetPublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemGetRequest{
-					ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 				resp: &core.Item{
 					ID:          uuid.MustParse("00000000-0000-0000-0000-000000000001"),
@@ -72,6 +74,26 @@ func TestRestItemGetPublic(t *testing.T) {
 				"createdAt":   "2021-01-01T00:00:00Z",
 				"updatedAt":   "2021-01-02T00:00:00Z",
 			},
+		},
+		{
+			name: "Error/AnonymousActor",
+
+			request: httptest.NewRequestWithContext(
+				t.Context(), http.MethodGet, "/item?id=00000000-0000-0000-0000-000000000001", nil,
+			),
+			claims: testClaimsAnonymous,
+
+			expectStatus: http.StatusForbidden,
+		},
+		{
+			name: "Error/MissingClaims",
+
+			request: httptest.NewRequestWithContext(
+				t.Context(), http.MethodGet, "/item?id=00000000-0000-0000-0000-000000000001", nil,
+			),
+			claims: testClaimsMissing,
+
+			expectStatus: http.StatusInternalServerError,
 		},
 		{
 			name: "Error/InvalidID",
@@ -97,7 +119,8 @@ func TestRestItemGetPublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemGetRequest{
-					ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 				err: dao.ErrItemGetNotFound,
 			},
@@ -116,7 +139,8 @@ func TestRestItemGetPublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemGetRequest{
-					ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 				},
 				err: errFoo,
 			},
@@ -140,7 +164,7 @@ func TestRestItemGetPublic(t *testing.T) {
 			handler := handlers.NewItemGetPublic(service, config.LoggerDev)
 			w := httptest.NewRecorder()
 
-			handler.ServeHTTP(w, testCase.request)
+			handler.ServeHTTP(w, withTestClaims(testCase.request, testCase.claims))
 
 			res := w.Result()
 

--- a/internal/handlers/http.itemListPublic.go
+++ b/internal/handlers/http.itemListPublic.go
@@ -40,9 +40,18 @@ func (handler *ItemListPublic) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	ctx, span := otel.Tracer().Start(r.Context(), "rest.ItemListPublic")
 	defer span.End()
 
+	actor, err := actorFromContext(ctx)
+	if err != nil {
+		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
+			ErrAnonymousActor: http.StatusForbidden,
+		}, err)
+
+		return
+	}
+
 	var request ItemListPublicRequest
 
-	err := muxDecoder.Decode(&request, r.URL.Query())
+	err = muxDecoder.Decode(&request, r.URL.Query())
 	if err != nil {
 		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{nil: http.StatusBadRequest}, err)
 
@@ -50,6 +59,7 @@ func (handler *ItemListPublic) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	items, err := handler.service.Exec(ctx, &core.ItemListRequest{
+		Actor:  *actor,
 		Limit:  request.Limit,
 		Offset: request.Offset,
 	})

--- a/internal/handlers/http.itemListPublic_test.go
+++ b/internal/handlers/http.itemListPublic_test.go
@@ -34,6 +34,7 @@ func TestRestItemListPublic(t *testing.T) {
 		name string
 
 		request *http.Request
+		claims  testClaimsState
 
 		serviceMock *serviceMock
 
@@ -46,7 +47,7 @@ func TestRestItemListPublic(t *testing.T) {
 			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items?limit=10&offset=0", nil),
 
 			serviceMock: &serviceMock{
-				req: &core.ItemListRequest{Limit: 10, Offset: 0},
+				req: &core.ItemListRequest{Actor: testActor, Limit: 10, Offset: 0},
 				resp: []*core.Item{
 					{
 						ID:        uuid.MustParse("00000000-0000-0000-0000-000000000002"),
@@ -80,12 +81,26 @@ func TestRestItemListPublic(t *testing.T) {
 			},
 		},
 		{
+			name: "Error/AnonymousActor",
+
+			request:      httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items", nil),
+			claims:       testClaimsAnonymous,
+			expectStatus: http.StatusForbidden,
+		},
+		{
+			name: "Error/MissingClaims",
+
+			request:      httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items", nil),
+			claims:       testClaimsMissing,
+			expectStatus: http.StatusInternalServerError,
+		},
+		{
 			name: "Error/Internal",
 
 			request: httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/items?limit=10&offset=0", nil),
 
 			serviceMock: &serviceMock{
-				req: &core.ItemListRequest{Limit: 10, Offset: 0},
+				req: &core.ItemListRequest{Actor: testActor, Limit: 10, Offset: 0},
 				err: errFoo,
 			},
 
@@ -108,7 +123,7 @@ func TestRestItemListPublic(t *testing.T) {
 			handler := handlers.NewItemListPublic(service, config.LoggerDev)
 			w := httptest.NewRecorder()
 
-			handler.ServeHTTP(w, testCase.request)
+			handler.ServeHTTP(w, withTestClaims(testCase.request, testCase.claims))
 
 			res := w.Result()
 

--- a/internal/handlers/http.itemUpdatePublic.go
+++ b/internal/handlers/http.itemUpdatePublic.go
@@ -43,11 +43,20 @@ func (handler *ItemUpdatePublic) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	ctx, span := otel.Tracer().Start(r.Context(), "rest.ItemUpdatePublic")
 	defer span.End()
 
+	actor, err := actorFromContext(ctx)
+	if err != nil {
+		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{
+			ErrAnonymousActor: http.StatusForbidden,
+		}, err)
+
+		return
+	}
+
 	decoder := json.NewDecoder(r.Body)
 
 	var request ItemUpdatePublicRequest
 
-	err := decoder.Decode(&request)
+	err = decoder.Decode(&request)
 	if err != nil {
 		httpf.HandleError(ctx, handler.logger, w, span, httpf.ErrMap{nil: http.StatusBadRequest}, err)
 
@@ -55,6 +64,7 @@ func (handler *ItemUpdatePublic) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	item, err := handler.service.Exec(ctx, &core.ItemUpdateRequest{
+		Actor:       *actor,
 		ID:          request.ID,
 		Name:        request.Name,
 		Description: request.Description,

--- a/internal/handlers/http.itemUpdatePublic_test.go
+++ b/internal/handlers/http.itemUpdatePublic_test.go
@@ -36,6 +36,7 @@ func TestRestItemUpdatePublic(t *testing.T) {
 		name string
 
 		request *http.Request
+		claims  testClaimsState
 
 		serviceMock *serviceMock
 
@@ -53,6 +54,7 @@ func TestRestItemUpdatePublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemUpdateRequest{
+					Actor:       testActor,
 					ID:          uuid.MustParse("00000000-0000-0000-0000-000000000001"),
 					Name:        "updated item",
 					Description: "updated description",
@@ -74,6 +76,20 @@ func TestRestItemUpdatePublic(t *testing.T) {
 				"createdAt":   "2021-01-01T00:00:00Z",
 				"updatedAt":   "2021-01-02T00:00:00Z",
 			},
+		},
+		{
+			name: "Error/AnonymousActor",
+
+			request:      httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/item", strings.NewReader(`{}`)),
+			claims:       testClaimsAnonymous,
+			expectStatus: http.StatusForbidden,
+		},
+		{
+			name: "Error/MissingClaims",
+
+			request:      httptest.NewRequestWithContext(t.Context(), http.MethodPut, "/item", strings.NewReader(`{}`)),
+			claims:       testClaimsMissing,
+			expectStatus: http.StatusInternalServerError,
 		},
 		{
 			name: "Error/InvalidBody",
@@ -102,8 +118,9 @@ func TestRestItemUpdatePublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemUpdateRequest{
-					ID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Name: "",
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Name:  "",
 				},
 				err: core.ErrInvalidRequest,
 			},
@@ -120,8 +137,9 @@ func TestRestItemUpdatePublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemUpdateRequest{
-					ID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Name: "updated item",
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Name:  "updated item",
 				},
 				err: dao.ErrItemUpdateNotFound,
 			},
@@ -138,8 +156,9 @@ func TestRestItemUpdatePublic(t *testing.T) {
 
 			serviceMock: &serviceMock{
 				req: &core.ItemUpdateRequest{
-					ID:   uuid.MustParse("00000000-0000-0000-0000-000000000001"),
-					Name: "updated item",
+					Actor: testActor,
+					ID:    uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+					Name:  "updated item",
 				},
 				err: errFoo,
 			},
@@ -163,7 +182,7 @@ func TestRestItemUpdatePublic(t *testing.T) {
 			handler := handlers.NewItemUpdatePublic(service, config.LoggerDev)
 			w := httptest.NewRecorder()
 
-			handler.ServeHTTP(w, testCase.request)
+			handler.ServeHTTP(w, withTestClaims(testCase.request, testCase.claims))
 
 			res := w.Result()
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -19,6 +19,9 @@ info:
     name: AGPL-3.0
     url: "https://raw.githubusercontent.com/a-novel/service-narrative-engine/refs/heads/master/LICENSE"
 
+security:
+  - BearerAuth: []
+
 paths:
   /ping:
     get:
@@ -62,7 +65,8 @@ paths:
       description: |
         Creates a new item with the given name and optional description.
       tags: [item]
-      security: []
+      security:
+        - BearerAuth: ["narrative:item:write"]
       requestBody:
         required: true
         content:
@@ -74,6 +78,10 @@ paths:
           $ref: "#/components/responses/item"
         "400":
           $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
         default:
           $ref: "#/components/responses/internalError"
 
@@ -83,7 +91,8 @@ paths:
       description: |
         Returns a paginated list of items, ordered by creation date descending.
       tags: [item]
-      security: []
+      security:
+        - BearerAuth: ["narrative:item:read"]
       parameters:
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/offset"
@@ -92,6 +101,10 @@ paths:
           $ref: "#/components/responses/itemList"
         "400":
           $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
         default:
           $ref: "#/components/responses/internalError"
 
@@ -102,7 +115,8 @@ paths:
       description: |
         Returns a single item by its unique identifier.
       tags: [item]
-      security: []
+      security:
+        - BearerAuth: ["narrative:item:read"]
       parameters:
         - $ref: "#/components/parameters/itemID"
       responses:
@@ -110,6 +124,10 @@ paths:
           $ref: "#/components/responses/item"
         "400":
           $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
         "404":
           $ref: "#/components/responses/notFound"
         default:
@@ -121,7 +139,8 @@ paths:
       description: |
         Updates the name and description of an existing item.
       tags: [item]
-      security: []
+      security:
+        - BearerAuth: ["narrative:item:write"]
       requestBody:
         required: true
         content:
@@ -133,6 +152,10 @@ paths:
           $ref: "#/components/responses/item"
         "400":
           $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
         "404":
           $ref: "#/components/responses/notFound"
         default:
@@ -144,7 +167,8 @@ paths:
       description: |
         Permanently deletes an item by its unique identifier. Returns the deleted item.
       tags: [item]
-      security: []
+      security:
+        - BearerAuth: ["narrative:item:write"]
       parameters:
         - $ref: "#/components/parameters/itemID"
       responses:
@@ -152,12 +176,25 @@ paths:
           $ref: "#/components/responses/item"
         "400":
           $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "403":
+          $ref: "#/components/responses/forbidden"
         "404":
           $ref: "#/components/responses/notFound"
         default:
           $ref: "#/components/responses/internalError"
 
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        A JWT access token. The Authorization header must use `Bearer`, followed
+        by exactly one space and the token.
+
   responses:
     pong:
       description: A plain-text pong response.
@@ -204,6 +241,18 @@ components:
     badRequest:
       description: |
         The request sent to the server could not be parsed, or failed validation.
+
+    unauthorized:
+      description: A valid bearer access token is required.
+      headers:
+        WWW-Authenticate:
+          description: Bearer authentication challenge.
+          schema:
+            type: string
+            examples: ['Bearer realm="narrative-engine", error="invalid_token"']
+
+    forbidden:
+      description: The authenticated actor lacks a required permission.
 
     internalError:
       description: Something unexpected happened.

--- a/pkg/js/rest/src/item.ts
+++ b/pkg/js/rest/src/item.ts
@@ -64,52 +64,69 @@ export const ItemDeleteRequestSchema = z.object({
 export type ItemDeleteRequest = z.infer<typeof ItemDeleteRequestSchema>;
 
 /** Creates an Item with the given name and optional description, returning the stored record. */
-export async function itemCreate(api: NarrativeEngineApi, name: string, description?: string): Promise<Item> {
+export async function itemCreate(
+  api: NarrativeEngineApi,
+  accessToken: string,
+  name: string,
+  description?: string
+): Promise<Item> {
   return await api.fetch("/items", ItemSchema, {
     method: "POST",
-    headers: HTTP_HEADERS.JSON,
+    headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     body: JSON.stringify({ name, description }),
   });
 }
 
 /** Returns a single Item by its ID. */
-export async function itemGet(api: NarrativeEngineApi, id: string): Promise<Item> {
+export async function itemGet(api: NarrativeEngineApi, accessToken: string, id: string): Promise<Item> {
   const params = new URLSearchParams();
   params.set("id", id);
-  return await api.fetch(`/item?${params.toString()}`, ItemSchema, { method: "GET", headers: HTTP_HEADERS.JSON });
+  return await api.fetch(`/item?${params.toString()}`, ItemSchema, {
+    method: "GET",
+    headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
+  });
 }
 
 /**
  * Returns a page of Items. `limit` defaults to 100 and `offset` to 0 when omitted; a `limit` of 0
  * also falls back to 100.
  */
-export async function itemList(api: NarrativeEngineApi, limit?: number, offset?: number): Promise<Item[]> {
+export async function itemList(
+  api: NarrativeEngineApi,
+  accessToken: string,
+  limit?: number,
+  offset?: number
+): Promise<Item[]> {
   const params = new URLSearchParams();
   params.set("limit", `${limit || 100}`);
   params.set("offset", `${offset || 0}`);
   return await api.fetch(`/items?${params.toString()}`, z.array(ItemSchema), {
     method: "GET",
-    headers: HTTP_HEADERS.JSON,
+    headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
   });
 }
 
 /** Replaces the name and description of the Item with the given ID, returning the updated record. */
 export async function itemUpdate(
   api: NarrativeEngineApi,
+  accessToken: string,
   id: string,
   name: string,
   description?: string
 ): Promise<Item> {
   return await api.fetch(`/item`, ItemSchema, {
     method: "PUT",
-    headers: HTTP_HEADERS.JSON,
+    headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
     body: JSON.stringify({ id, name, description }),
   });
 }
 
 /** Deletes the Item with the given ID, returning the deleted record. */
-export async function itemDelete(api: NarrativeEngineApi, id: string): Promise<Item> {
+export async function itemDelete(api: NarrativeEngineApi, accessToken: string, id: string): Promise<Item> {
   const params = new URLSearchParams();
   params.set("id", id);
-  return await api.fetch(`/item?${params.toString()}`, ItemSchema, { method: "DELETE", headers: HTTP_HEADERS.JSON });
+  return await api.fetch(`/item?${params.toString()}`, ItemSchema, {
+    method: "DELETE",
+    headers: { ...HTTP_HEADERS.JSON, Authorization: `Bearer ${accessToken}` },
+  });
 }

--- a/pkg/js/test/rest/src/item.test.ts
+++ b/pkg/js/test/rest/src/item.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { anonymousAccessToken, superAdminAccessToken } from "./token";
+
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { expectStatus } from "@a-novel-kit/nodelib-test/http";
 import {
@@ -10,10 +12,16 @@ import {
   itemUpdate,
 } from "@a-novel/service-narrative-engine-rest";
 
+let accessToken: string;
+
+beforeAll(async () => {
+  accessToken = await superAdminAccessToken();
+});
+
 describe("itemCreate", () => {
   it("creates a new item", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    const item = await itemCreate(api, "test item", "test description");
+    const item = await itemCreate(api, accessToken, "test item", "test description");
 
     expect(item.id).toBeTruthy();
     expect(item.name).toBe("test item");
@@ -21,116 +29,130 @@ describe("itemCreate", () => {
     expect(item.createdAt).toBeTruthy();
     expect(item.updatedAt).toBeTruthy();
 
-    await itemDelete(api, item.id);
+    await itemDelete(api, accessToken, item.id);
   });
 
   it("creates an item without description", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    const item = await itemCreate(api, "no description item");
+    const item = await itemCreate(api, accessToken, "no description item");
 
     expect(item.id).toBeTruthy();
     expect(item.name).toBe("no description item");
 
-    await itemDelete(api, item.id);
+    await itemDelete(api, accessToken, item.id);
   });
 
   it("returns 400 for empty name", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    await expectStatus(itemCreate(api, ""), 400);
+    await expectStatus(itemCreate(api, accessToken, ""), 400);
   });
 });
 
 describe("itemGet", () => {
   it("retrieves an existing item", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    const created = await itemCreate(api, "item to get");
+    const created = await itemCreate(api, accessToken, "item to get");
 
-    const item = await itemGet(api, created.id);
+    const item = await itemGet(api, accessToken, created.id);
     expect(item.id).toBe(created.id);
     expect(item.name).toBe("item to get");
 
-    await itemDelete(api, created.id);
+    await itemDelete(api, accessToken, created.id);
   });
 
   it("returns 400 for invalid ID format", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    await expectStatus(itemGet(api, "not-a-uuid"), 400);
+    await expectStatus(itemGet(api, accessToken, "not-a-uuid"), 400);
   });
 
   it("returns 404 for non-existent item", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    await expectStatus(itemGet(api, "00000000-0000-0000-0000-000000000001"), 404);
+    await expectStatus(itemGet(api, accessToken, "00000000-0000-0000-0000-000000000001"), 404);
   });
 });
 
 describe("itemList", () => {
   it("returns a list of items", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    const items = await itemList(api);
+    const items = await itemList(api, accessToken);
 
     expect(Array.isArray(items)).toBe(true);
   });
 
   it("respects limit and offset", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    const items = await itemList(api, 10, 0);
+    const items = await itemList(api, accessToken, 10, 0);
 
     expect(Array.isArray(items)).toBe(true);
     expect(items.length).toBeLessThanOrEqual(10);
+  });
+
+  it("returns 401 with a bearer challenge when the token is missing", async () => {
+    const response = await fetch(`${process.env.REST_URL!}/items`);
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toBe(`Bearer realm="narrative-engine", error="invalid_token"`);
+  });
+
+  it("returns 403 when the token lacks the read permission", async () => {
+    const api = new NarrativeEngineApi(process.env.REST_URL!);
+    const anonymousToken = await anonymousAccessToken();
+
+    await expectStatus(itemList(api, anonymousToken), 403);
   });
 });
 
 describe("itemUpdate", () => {
   it("updates an existing item", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    const created = await itemCreate(api, "item to update");
+    const created = await itemCreate(api, accessToken, "item to update");
 
-    const updated = await itemUpdate(api, created.id, "updated name", "updated description");
+    const updated = await itemUpdate(api, accessToken, created.id, "updated name", "updated description");
     expect(updated.id).toBe(created.id);
     expect(updated.name).toBe("updated name");
     expect(updated.description).toBe("updated description");
 
-    await itemDelete(api, created.id);
+    await itemDelete(api, accessToken, created.id);
   });
 
   it("returns 400 for invalid ID format", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    await expectStatus(itemUpdate(api, "not-a-uuid", "name"), 400);
+    await expectStatus(itemUpdate(api, accessToken, "not-a-uuid", "name"), 400);
   });
 
   it("returns 404 for non-existent item", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    await expectStatus(itemUpdate(api, "00000000-0000-0000-0000-000000000000", "name"), 404);
+    await expectStatus(itemUpdate(api, accessToken, "00000000-0000-0000-0000-000000000000", "name"), 404);
   });
 
   it("returns 400 for empty name", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    const created = await itemCreate(api, "item for empty name test");
+    const created = await itemCreate(api, accessToken, "item for empty name test");
 
-    await expectStatus(itemUpdate(api, created.id, ""), 400);
+    await expectStatus(itemUpdate(api, accessToken, created.id, ""), 400);
 
-    await itemDelete(api, created.id);
+    await itemDelete(api, accessToken, created.id);
   });
 });
 
 describe("itemDelete", () => {
   it("deletes an existing item", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    const created = await itemCreate(api, "item to delete");
+    const created = await itemCreate(api, accessToken, "item to delete");
 
-    const deleted = await itemDelete(api, created.id);
+    const deleted = await itemDelete(api, accessToken, created.id);
     expect(deleted.id).toBe(created.id);
 
-    await expectStatus(itemGet(api, created.id), 404);
+    await expectStatus(itemGet(api, accessToken, created.id), 404);
   });
 
   it("returns 400 for invalid ID format", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    await expectStatus(itemDelete(api, "not-a-uuid"), 400);
+    await expectStatus(itemDelete(api, accessToken, "not-a-uuid"), 400);
   });
 
   it("returns 404 for non-existent item", async () => {
     const api = new NarrativeEngineApi(process.env.REST_URL!);
-    await expectStatus(itemDelete(api, "00000000-0000-0000-0000-000000000001"), 404);
+    await expectStatus(itemDelete(api, accessToken, "00000000-0000-0000-0000-000000000001"), 404);
   });
 });

--- a/pkg/js/test/rest/src/token.ts
+++ b/pkg/js/test/rest/src/token.ts
@@ -1,4 +1,11 @@
-import { AuthenticationApi, tokenCreate } from "@a-novel/service-authentication-rest";
+import { AuthenticationApi, tokenCreate, tokenCreateAnon } from "@a-novel/service-authentication-rest";
+
+/** Opens an anonymous integration session and returns its access token. */
+export async function anonymousAccessToken(): Promise<string> {
+  const api = new AuthenticationApi(process.env.SERVICE_AUTHENTICATION_URL!);
+  const { accessToken } = await tokenCreateAnon(api);
+  return accessToken;
+}
 
 /** Logs in as the integration super-admin and returns its access token. */
 export async function superAdminAccessToken(): Promise<string> {


### PR DESCRIPTION
## Summary

- Makes authentication mandatory for every placeholder item route and passes a provider-neutral Actor into the service layer.
- Keeps authorization at the route boundary while rejecting anonymous claims as 403 and treating absent claims as a 500 wiring error.
- Publishes the bearer contract and sends access tokens per JavaScript client call, with live 401/403 integration coverage.

## Layers changed

- **Core**: adds the Actor value and validates it on item service requests.
- **REST**: extracts actors, mounts permission-gated route groups, and adds the 401 bearer challenge.
- **Client/API**: aligns OpenAPI, the JavaScript client, integration tests, and the README example.

## Permission review

- `POST /items` -> `narrative:item:write`
- `GET /items` -> `narrative:item:read`
- `GET /item` -> `narrative:item:read`
- `PUT /item` -> `narrative:item:write`
- `DELETE /item` -> `narrative:item:write`

## Breaking changes

- Item routes now require a valid bearer access token.
- `itemCreate`, `itemGet`, `itemList`, `itemUpdate`, and `itemDelete` now take an access token immediately after the API client. Callers must obtain a token from the authentication service and pass it per call.

## Test plan

- [x] `pnpm lint:go`
- [x] `pnpm lint:js`
- [x] `a-novel test --type=go -y`
- [x] `a-novel test --type=pnpm -y`
- [x] `a-novel build --type=go,pnpm -y`
- [x] Root mock generation leaves generated mocks and `.mockery.yaml` unchanged
- [x] CI green

Closes #429
