### PR TITLE
ci(ci): centralize service topology with Compose

### DIFF
--- a/.github/actions/start-ci-services/action.yml
+++ b/.github/actions/start-ci-services/action.yml
@@ -1,0 +1,97 @@
+name: start-ci-services
+description: Start and wait for the requested CI Compose topology.
+
+inputs:
+  services:
+    required: true
+    description: Space-separated Compose services to start.
+  database_image:
+    required: false
+    default: service-narrative-engine-database:ci
+    description: Narrative database image reference.
+  standalone_rest_image:
+    required: false
+    default: service-narrative-engine-standalone-rest:ci
+    description: Narrative standalone REST image reference.
+  json_keys_database_image:
+    required: false
+    default: ghcr.io/a-novel/service-json-keys/database:v2.4.1
+    description: JSON keys database image reference.
+  json_keys_grpc_image:
+    required: false
+    default: ghcr.io/a-novel/service-json-keys/standalone-grpc:v2.4.1
+    description: JSON keys gRPC image reference.
+  authentication_database_image:
+    required: false
+    default: ghcr.io/a-novel/service-authentication/database:v2.4.5
+    description: Authentication database image reference.
+  authentication_rest_image:
+    required: false
+    default: ghcr.io/a-novel/service-authentication/standalone-rest:v2.4.5
+    description: Authentication REST image reference.
+  jobs_database_image:
+    required: false
+    default: ghcr.io/a-novel/service-jobs/database:v0.2.1
+    description: Jobs database image reference.
+  jobs_migrations_image:
+    required: false
+    default: ghcr.io/a-novel/service-jobs/jobs/migrations:v0.2.1
+    description: Jobs migrations image reference.
+  jobs_grpc_image:
+    required: false
+    default: ghcr.io/a-novel/service-jobs/standalone-grpc:v0.2.1
+    description: Jobs gRPC image reference.
+  registry_login:
+    required: false
+    default: "false"
+    description: When "true", authenticate to ghcr.io with the current job token.
+
+runs:
+  using: composite
+  steps:
+    - name: Log in to the container registry
+      if: inputs.registry_login == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REGISTRY_USERNAME: ${{ github.actor }}
+      run: |
+        set -euo pipefail
+        printf '%s' "${GH_TOKEN}" | docker login ghcr.io --username "${REGISTRY_USERNAME}" --password-stdin
+
+    - name: Start CI services
+      shell: bash
+      env:
+        CI_SERVICES: ${{ inputs.services }}
+        COMPOSE_PROJECT_NAME: ci-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+        DATABASE_IMAGE: ${{ inputs.database_image }}
+        STANDALONE_REST_IMAGE: ${{ inputs.standalone_rest_image }}
+        JSON_KEYS_DATABASE_IMAGE: ${{ inputs.json_keys_database_image }}
+        JSON_KEYS_GRPC_IMAGE: ${{ inputs.json_keys_grpc_image }}
+        AUTHENTICATION_DATABASE_IMAGE: ${{ inputs.authentication_database_image }}
+        AUTHENTICATION_REST_IMAGE: ${{ inputs.authentication_rest_image }}
+        JOBS_DATABASE_IMAGE: ${{ inputs.jobs_database_image }}
+        JOBS_MIGRATIONS_IMAGE: ${{ inputs.jobs_migrations_image }}
+        JOBS_GRPC_IMAGE: ${{ inputs.jobs_grpc_image }}
+        POSTGRES_PASSWORD: postgres
+      run: |
+        set -euo pipefail
+        read -r -a services <<< "${CI_SERVICES}"
+
+        set +e
+        docker compose --file builds/compose.ci.yaml up \
+          --detach \
+          --no-build \
+          --wait \
+          --wait-timeout 120 \
+          "${services[@]}"
+        status=$?
+        set -e
+
+        if (( status == 0 )); then
+          exit 0
+        fi
+
+        docker compose --file builds/compose.ci.yaml ps --all || true
+        docker compose --file builds/compose.ci.yaml logs --no-color || true
+        exit "${status}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -37,25 +37,19 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    services:
-      postgres:
-        image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+      packages: read
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - &start-local-database
+        uses: ./.github/actions/start-ci-services
+        with:
+          services: postgres
+          database_image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
+          registry_login: "true"
       - uses: a-novel-kit/workflows/go-actions/generate-go@v1.28.0
 
   lint-go:
@@ -154,30 +148,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
     outputs:
       artifact-id: ${{ steps.test.outputs.artifact-id }}
-    services:
-      postgres:
-        image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-local-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/go-actions/test-go@v1.28.0
         id: test
@@ -197,140 +177,21 @@ jobs:
       packages: read
     outputs:
       artifact-id: ${{ steps.test.outputs.artifact-id }}
-    services:
-      postgres-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/database:v2.4.1
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      service-json-keys:
-        image: ghcr.io/a-novel/service-json-keys/standalone-grpc:v2.4.1
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_DSN: postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable
-          APP_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
-        options: >-
-          --restart on-failure:10
-
-      postgres-authentication:
-        image: ghcr.io/a-novel/service-authentication/database:v2.4.5
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      service-authentication:
-        image: ghcr.io/a-novel/service-authentication/standalone-rest:v2.4.5
-        ports:
-          - "4000:8080"
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_DSN: postgres://postgres:postgres@postgres-authentication:5432/postgres?sslmode=disable
-          SERVICE_JSON_KEYS_HOST: service-json-keys
-          SERVICE_JSON_KEYS_PORT: 8080
-          SUPER_ADMIN_EMAIL: noreply@agorastoryverse.com
-          SUPER_ADMIN_PASSWORD: admin
-        options: >-
-          --restart on-failure:10
-
-      postgres-jobs:
-        image: ghcr.io/a-novel/service-jobs/database:v0.2.1
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      service-jobs-migrations:
-        image: ghcr.io/a-novel/service-jobs/jobs/migrations:v0.2.1
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_DSN: postgres://postgres:postgres@postgres-jobs:5432/postgres?sslmode=disable
-        options: >-
-          --restart on-failure:10
-
-      service-jobs:
-        image: ghcr.io/a-novel/service-jobs/standalone-grpc:v0.2.1
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_DSN: postgres://postgres:postgres@postgres-jobs:5432/postgres?sslmode=disable
-        options: >-
-          --restart on-failure:10
-
-      postgres-narrative-engine:
-        image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      service-narrative-engine:
-        image: ghcr.io/a-novel/service-narrative-engine/standalone-rest@${{ needs.build-standalone-rest.outputs.digest }}
-        ports:
-          - "8080:8080"
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          POSTGRES_DSN: postgres://postgres:postgres@postgres-narrative-engine:5432/postgres?sslmode=disable
-          SERVICE_JOBS_HOST: service-jobs
-          SERVICE_JOBS_PORT: 8080
-          SERVICE_JSON_KEYS_HOST: service-json-keys
-          SERVICE_JSON_KEYS_PORT: 8080
     env:
       REST_URL: "http://localhost:8080"
       SERVICE_AUTHENTICATION_URL: "http://localhost:4000"
       SUPER_ADMIN_EMAIL: noreply@agorastoryverse.com
       SUPER_ADMIN_PASSWORD: admin
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/start-ci-services
+        with:
+          services: standalone-rest service-authentication
+          database_image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
+          standalone_rest_image: ghcr.io/a-novel/service-narrative-engine/standalone-rest@${{ needs.build-standalone-rest.outputs.digest }}
+          registry_login: "true"
       - uses: a-novel-kit/workflows/node-actions/test-node@v1.28.0
         id: test
         with:
@@ -349,12 +210,6 @@ jobs:
       id-token: write
     outputs:
       digest: ${{ steps.build.outputs.digest }}
-    env:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-      POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         id: build
@@ -363,12 +218,7 @@ jobs:
           image_name: ${{ github.repository }}/database
           cache: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_args: >-
-            -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" 
-            -e POSTGRES_USER="${POSTGRES_USER}" 
-            -e POSTGRES_DB="${POSTGRES_DB}"
-            -e POSTGRES_HOST_AUTH_METHOD="${POSTGRES_HOST_AUTH_METHOD}"
-            -e POSTGRES_INITDB_ARGS="${POSTGRES_INITDB_ARGS}"
+          run_args: -e POSTGRES_PASSWORD=postgres
 
   build-migrations:
     runs-on: ubuntu-latest
@@ -378,25 +228,13 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-narrative-engine:
-        image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - *start-local-database
       - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/migrations.Dockerfile
@@ -412,28 +250,13 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-narrative-engine:
-        image: ghcr.io/a-novel/service-narrative-engine/database@${{ needs.build-database.outputs.digest }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-local-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,12 +66,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    env:
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-      POSTGRES_INITDB_ARGS: --auth=scram-sha-256
     steps:
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
@@ -80,12 +74,7 @@ jobs:
           cache: false
           version: ${{ needs.release.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_args: >-
-            -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}"
-            -e POSTGRES_USER="${POSTGRES_USER}"
-            -e POSTGRES_DB="${POSTGRES_DB}"
-            -e POSTGRES_HOST_AUTH_METHOD="${POSTGRES_HOST_AUTH_METHOD}"
-            -e POSTGRES_INITDB_ARGS="${POSTGRES_INITDB_ARGS}"
+          run_args: -e POSTGRES_PASSWORD=postgres
 
   build-migrations:
     runs-on: ubuntu-latest
@@ -96,25 +85,18 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-narrative-engine:
-        image: ghcr.io/a-novel/service-narrative-engine/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - &start-release-database
+        uses: ./.github/actions/start-ci-services
+        with:
+          services: postgres
+          database_image: ghcr.io/a-novel/service-narrative-engine/database:${{ needs.release.outputs.tag }}
+          registry_login: "true"
       - uses: a-novel-kit/workflows/build-actions/docker-job@v1.28.0
         with:
           file: builds/migrations.Dockerfile
@@ -132,28 +114,13 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-narrative-engine:
-        image: ghcr.io/a-novel/service-narrative-engine/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-release-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:
@@ -172,28 +139,13 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    services:
-      postgres-narrative-engine:
-        image: ghcr.io/a-novel/service-narrative-engine/database:${{ needs.release.outputs.tag }}
-        ports:
-          - "5432:5432"
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_HOST_AUTH_METHOD: scram-sha-256
-          POSTGRES_INITDB_ARGS: --auth=scram-sha-256
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     env:
       POSTGRES_DSN: postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable
     steps:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+      - *start-release-database
       - uses: ./.github/actions/run-migrations
       - uses: a-novel-kit/workflows/build-actions/docker@v1.28.0
         with:

--- a/builds/compose.ci.yaml
+++ b/builds/compose.ci.yaml
@@ -1,0 +1,99 @@
+x-external-postgres-environment: &external-postgres-environment
+  POSTGRES_PASSWORD: postgres
+  POSTGRES_USER: postgres
+  POSTGRES_DB: postgres
+  POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+  POSTGRES_INITDB_ARGS: --auth=scram-sha-256
+
+x-postgres-healthcheck: &postgres-healthcheck
+  test: ["CMD", "pg_isready"]
+  interval: 10s
+  timeout: 5s
+  retries: 5
+
+services:
+  postgres:
+    image: "${DATABASE_IMAGE:?DATABASE_IMAGE is required}"
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+    healthcheck: *postgres-healthcheck
+
+  postgres-json-keys:
+    image: "${JSON_KEYS_DATABASE_IMAGE:?JSON_KEYS_DATABASE_IMAGE is required}"
+    environment: *external-postgres-environment
+    healthcheck: *postgres-healthcheck
+
+  service-json-keys:
+    image: "${JSON_KEYS_GRPC_IMAGE:?JSON_KEYS_GRPC_IMAGE is required}"
+    restart: on-failure:10
+    depends_on:
+      postgres-json-keys:
+        condition: service_healthy
+    environment:
+      POSTGRES_DSN: postgres://postgres:postgres@postgres-json-keys:5432/postgres?sslmode=disable
+      APP_MASTER_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
+
+  postgres-authentication:
+    image: "${AUTHENTICATION_DATABASE_IMAGE:?AUTHENTICATION_DATABASE_IMAGE is required}"
+    environment: *external-postgres-environment
+    healthcheck: *postgres-healthcheck
+
+  service-authentication:
+    image: "${AUTHENTICATION_REST_IMAGE:?AUTHENTICATION_REST_IMAGE is required}"
+    restart: on-failure:10
+    ports:
+      - "4000:8080"
+    depends_on:
+      postgres-authentication:
+        condition: service_healthy
+      service-json-keys:
+        condition: service_healthy
+    environment:
+      POSTGRES_DSN: postgres://postgres:postgres@postgres-authentication:5432/postgres?sslmode=disable
+      SERVICE_JSON_KEYS_HOST: service-json-keys
+      SERVICE_JSON_KEYS_PORT: 8080
+      SUPER_ADMIN_EMAIL: noreply@agorastoryverse.com
+      SUPER_ADMIN_PASSWORD: admin
+
+  postgres-jobs:
+    image: "${JOBS_DATABASE_IMAGE:?JOBS_DATABASE_IMAGE is required}"
+    environment: *external-postgres-environment
+    healthcheck: *postgres-healthcheck
+
+  service-jobs-migrations:
+    image: "${JOBS_MIGRATIONS_IMAGE:?JOBS_MIGRATIONS_IMAGE is required}"
+    restart: on-failure:10
+    depends_on:
+      postgres-jobs:
+        condition: service_healthy
+    environment:
+      POSTGRES_DSN: postgres://postgres:postgres@postgres-jobs:5432/postgres?sslmode=disable
+
+  service-jobs:
+    image: "${JOBS_GRPC_IMAGE:?JOBS_GRPC_IMAGE is required}"
+    restart: on-failure:10
+    depends_on:
+      service-jobs-migrations:
+        condition: service_completed_successfully
+    environment:
+      POSTGRES_DSN: postgres://postgres:postgres@postgres-jobs:5432/postgres?sslmode=disable
+
+  standalone-rest:
+    image: "${STANDALONE_REST_IMAGE:?STANDALONE_REST_IMAGE is required}"
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      service-json-keys:
+        condition: service_healthy
+      service-jobs:
+        condition: service_healthy
+    environment:
+      POSTGRES_DSN: postgres://postgres:postgres@postgres:5432/postgres?sslmode=disable
+      SERVICE_JOBS_HOST: service-jobs
+      SERVICE_JOBS_PORT: 8080
+      SERVICE_JSON_KEYS_HOST: service-json-keys
+      SERVICE_JSON_KEYS_PORT: 8080

--- a/builds/database.Dockerfile
+++ b/builds/database.Dockerfile
@@ -3,6 +3,8 @@
 # It does not run the service's schema migrations; run the migrations target separately.
 FROM docker.io/library/postgres:18.4
 
+ENV POSTGRES_INITDB_ARGS=--auth=scram-sha-256
+
 ARG DEBIAN_FRONTEND=noninteractive
 
 # ======================================================================================================================


### PR DESCRIPTION
## Summary

- Centralizes PostgreSQL and the full REST integration constellation in one selective Compose topology.
- Preserves every dedicated image-build check and passes the exact database and standalone REST digests into their consumers.
- Removes job-level service duplication from branch and release workflows; Compose only starts images and never builds them.
- Makes SCRAM initialization a database-image default so local database consumers pass only the password.

## Breaking changes

None.

## Test plan

- [x] `pnpm lint:stylecheck`
- [x] Full Compose topology renders with digest-pinned local images and pinned dependency images
- [x] `builds/database.Dockerfile` builds with Podman
- [x] CI green (Epic merge gate awaits member approvals)

Closes #492